### PR TITLE
Update rxdart 0.22.6 -> 0.23.1

### DIFF
--- a/lib/just_audio.dart
+++ b/lib/just_audio.dart
@@ -107,9 +107,9 @@ class AudioPlayer {
   /// A stream periodically tracking the current position of this player.
   Stream<Duration> getPositionStream(
           [final Duration period = const Duration(milliseconds: 200)]) =>
-      Observable.combineLatest2<AudioPlayerState, void, Duration>(
+      Rx.combineLatest2<AudioPlayerState, void, Duration>(
           playerStateStream,
-          Observable.periodic(period),
+          Stream.periodic(period),
           (state, _) => state.position);
 
   /// Loads audio media from a URL and returns the duration of that audio.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  rxdart: ^0.22.6
+  rxdart: ^0.23.1
   path: ^1.6.4
   path_provider: ^1.4.5
   flutter:


### PR DESCRIPTION
Allows `just_audio` 0.0.2 to be used with `audio_service` 0.5.5.