### PR TITLE
Allow "playbackState" to be called before setting a URL.

### DIFF
--- a/lib/just_audio.dart
+++ b/lib/just_audio.dart
@@ -108,7 +108,7 @@ class AudioPlayer {
       _playbackEventSubject.stream;
 
   /// The current [AudioPlaybackState].
-  AudioPlaybackState get playbackState => _audioPlaybackEvent.state;
+  AudioPlaybackState get playbackState => _audioPlaybackEvent?.state ?? AudioPlaybackState.none;
 
   /// A stream of [AudioPlaybackState]s.
   Stream<AudioPlaybackState> get playbackStateStream =>


### PR DESCRIPTION
Currently, when calling `playbackState` on an `AudioPlayer` instance before `setUrl` has been called at least once, a `NoSuchMethodError` is thrown. I would expect either `null` or `AudioPlaybackState.none` to be returned.

Test:
```dart
AudioPlayer player = AudioPlayer();
print(player.playbackState); // NoSuchMethodError
await player.setUrl("https://s3.amazonaws.com/scifri-episodes/scifri20181123-episode.mp3");
await player.play();
```
Stacktrace: 
```
E/flutter ( 5492): [ERROR:flutter/lib/ui/ui_dart_state.cc(157)] Unhandled Exception: NoSuchMethodError: The getter 'state' was called on null.
E/flutter ( 5492): Receiver: null
E/flutter ( 5492): Tried calling: state
E/flutter ( 5492): #0      Object.noSuchMethod (dart:core-patch/object_patch.dart:53:5)
E/flutter ( 5492): #1      AudioPlayer.playbackState (package:just_audio/just_audio.dart:111:63)
```

This patch has it return `AudioPlaybackState.none` if no value is yet present. 