### PR TITLE
Enable playing local files in iOs.

### DIFF
--- a/ios/Classes/AudioPlayer.m
+++ b/ios/Classes/AudioPlayer.m
@@ -155,7 +155,16 @@
 		[[NSNotificationCenter defaultCenter] removeObserver:_endObserver];
 		_endObserver = 0;
 	}
-	AVPlayerItem* playerItem = [[AVPlayerItem alloc] initWithURL:[NSURL URLWithString:url]];
+
+    AVPlayerItem *playerItem;
+
+	//Allow iOs playing both external links and local files.
+    if ([url hasPrefix:@"/"]) {
+    	playerItem = [[AVPlayerItem alloc] initWithURL:[NSURL fileURLWithPath:url]];
+    } else {
+    	playerItem = [[AVPlayerItem alloc] initWithURL:[NSURL URLWithString:url]];
+    }
+
 	[playerItem addObserver:self
 		     forKeyPath:@"status"
 			options:NSKeyValueObservingOptionNew

--- a/lib/just_audio.dart
+++ b/lib/just_audio.dart
@@ -145,7 +145,7 @@ class AudioPlayer {
   /// audio, or null if this call was interrupted by another call so [setUrl],
   /// [setFilePath] or [setAsset].
   Future<Duration> setFilePath(final String filePath) =>
-      setUrl('file://$filePath');
+      setUrl('$filePath');
 
   /// Loads audio media from an asset and completes with the duration of that
   /// audio, or null if this call was interrupted by another call so [setUrl],


### PR DESCRIPTION
There is no need to prefix a local file path with "file://". We just need to use 'fileURLWithPath:url'.

Tested with both .mp3 and .m4a files on iPhone 8 emulator and iPhone 11 device.