### PR TITLE
Forward ExoPlaybackException exceptions to the Flutter plugin

### DIFF
--- a/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
+++ b/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
@@ -349,6 +349,10 @@ public class AudioPlayer implements MethodCallHandler, Player.EventListener, Met
 			prepareResult.error(errorCode, errorMsg, null);
 			prepareResult = null;
 		}
+
+		if (eventSink != null) {
+			eventSink.error(errorCode, errorMsg, null);
+		}
 	}
 
 	private void transition(final PlaybackState newState) {

--- a/lib/just_audio.dart
+++ b/lib/just_audio.dart
@@ -132,7 +132,7 @@ class AudioPlayer {
                           isPublic: data[5][1][5])),
             ));
     _eventChannelStreamSubscription =
-        _eventChannelStream.listen(_playbackEventSubject.add);
+        _eventChannelStream.listen(_playbackEventSubject.add, onError: _playbackEventSubject.addError);
     _playbackStateSubject
         .addStream(playbackEventStream.map((state) => state.state).distinct());
     _bufferingSubject.addStream(

--- a/lib/just_audio.dart
+++ b/lib/just_audio.dart
@@ -134,13 +134,13 @@ class AudioPlayer {
     _eventChannelStreamSubscription =
         _eventChannelStream.listen(_playbackEventSubject.add, onError: _playbackEventSubject.addError);
     _playbackStateSubject
-        .addStream(playbackEventStream.map((state) => state.state).distinct());
+        .addStream(playbackEventStream.map((state) => state.state).distinct().handleError((err,stack){ /* noop */ }));
     _bufferingSubject.addStream(
-        playbackEventStream.map((state) => state.buffering).distinct());
+        playbackEventStream.map((state) => state.buffering).distinct().handleError((err,stack){ /* noop */ }));
     _bufferedPositionSubject.addStream(
-        playbackEventStream.map((state) => state.bufferedPosition).distinct());
+        playbackEventStream.map((state) => state.bufferedPosition).distinct().handleError((err,stack){ /* noop */ }));
     _icyMetadataSubject.addStream(
-        playbackEventStream.map((state) => state.icyMetadata).distinct());
+        playbackEventStream.map((state) => state.icyMetadata).distinct().handleError((err,stack){ /* noop */ }));
     _fullPlaybackStateSubject.addStream(Rx.combineLatest3<AudioPlaybackState,
             bool, IcyMetadata, FullAudioPlaybackState>(
         playbackStateStream,


### PR DESCRIPTION
Following up on #76, I've modified the Android code to forward any playback exception thrown by ExoPlayer to the Flutter plugin. This allows reacting to exceptions thrown while playing audio (connection errors, unexpected exceptions...).
In my current solution, the error events are only passed to `playbackEventStream`, while all the other streams ignore them.