### PR TITLE
Fix RangeError on web client.

### DIFF
--- a/lib/just_audio.dart
+++ b/lib/just_audio.dart
@@ -119,7 +119,7 @@ class AudioPlayer {
               bufferedPosition: Duration(milliseconds: data[4]),
               speed: _speed,
               duration: _duration,
-              icyMetadata: data[5] == null
+              icyMetadata: data.length < 6 || data[5] == null
                   ? null
                   : IcyMetadata(
                       info: IcyInfo(title: data[5][0][0], url: data[5][0][1]),


### PR DESCRIPTION
Hi, I run your example on Chrome(web) and got an error:
```
errors.dart:146 Uncaught (in promise) Error: RangeError (index): Index out of range: index should be less than 5: 5
    at Object.throw_ [as throw] (errors.dart:195)
    at Array.[dartx._get] (js_array.dart:577)
    at Object._checkAndCall (operations.dart:306)
    at Object.callMethod (operations.dart:370)
    at Object.dsend (operations.dart:374)
    at _MapStream.new.<anonymous> (just_audio.dart:122)
    at _MapStream.new.[_handleData] (stream_pipe.dart:229)
    at _ForwardingStreamSubscription.new.[_handleData] (stream_pipe.dart:166)
    at _RootZone.runUnaryGuarded (zone.dart:1374)
    at _BroadcastSubscription.new.[_sendData] (stream_impl.dart:339)
    at _DelayedData.new.perform (stream_impl.dart:594)
    at _StreamImplEvents.new.handleNext (stream_impl.dart:710)
    at async._AsyncCallbackEntry.new.callback (stream_impl.dart:670)
    at Object._microtaskLoop (schedule_microtask.dart:43)
    at _startMicrotaskLoop (schedule_microtask.dart:52)
    at async_patch.dart:168
```
After small fix everything runs ok.