### PR TITLE
Fix infinity duration error on web platform

### DIFF
--- a/lib/just_audio_web.dart
+++ b/lib/just_audio_web.dart
@@ -154,7 +154,8 @@ class Html5AudioPlayer extends JustAudioPlayer {
     _audioElement.src = url;
     _audioElement.preload = 'auto';
     _audioElement.load();
-    final duration = await _durationCompleter.future;
+    var duration = await _durationCompleter.future;
+    duration = duration != double.infinity ? duration : 0;
     transition(AudioPlaybackState.stopped);
     return (duration * 1000).toInt();
   }


### PR DESCRIPTION
This will fix error while trying to load url from a backend that stream audio with unknown duration on web platform.

```
Error: Unsupported operation: Infinity
    at Object.createErrorWithStack (http://localhost:65222/dart_sdk.js:4786:12)
    at Object._rethrow (http://localhost:65222/dart_sdk.js:35900:16)
    at async._AsyncCallbackEntry.new.callback (http://localhost:65222/dart_sdk.js:35896:13)
    at Object._microtaskLoop (http://localhost:65222/dart_sdk.js:35756:13)
    at _startMicrotaskLoop (http://localhost:65222/dart_sdk.js:35762:13)
```