### PR TITLE
bug fix for audio seek when playback speed > 1.0

### DIFF
--- a/darwin/Classes/AudioPlayer.m
+++ b/darwin/Classes/AudioPlayer.m
@@ -1109,6 +1109,7 @@
                     [_player playImmediatelyAtRate:_speed];
                 } else {
                     [_player play];
+                    _player.rate = _speed;
                 }
             } else {
                 // If not playing, there is no reliable way to detect

--- a/darwin/Classes/AudioPlayer.m
+++ b/darwin/Classes/AudioPlayer.m
@@ -1105,7 +1105,11 @@
                 // If playing, buffering will be detected either by:
                 // 1. checkForDiscontinuity
                 // 2. timeControlStatus
-                [_player play];
+                if (@available(iOS 10.0, *)) {
+                    [_player playImmediatelyAtRate:_speed];
+                } else {
+                    [_player play];
+                }
             } else {
                 // If not playing, there is no reliable way to detect
                 // when buffering has completed, so we use

--- a/darwin/Classes/AudioPlayer.m
+++ b/darwin/Classes/AudioPlayer.m
@@ -1108,7 +1108,6 @@
                 if (@available(iOS 10.0, *)) {
                     [_player playImmediatelyAtRate:_speed];
                 } else {
-                    [_player play];
                     _player.rate = _speed;
                 }
             } else {


### PR DESCRIPTION
When seeking audio at playback rate > 1.0, after the seek, the playback rate was defaulting to 1.0
This should fix it and also make the seek slightly faster.
Please take a look!