### PR TITLE
Fix Airplay crash issue

### DIFF
--- a/darwin/Classes/UriAudioSource.m
+++ b/darwin/Classes/UriAudioSource.m
@@ -50,16 +50,19 @@
 
 - (void)seek:(CMTime)position completionHandler:(void (^)(BOOL))completionHandler {
     if (!completionHandler || (_playerItem.status == AVPlayerItemStatusReadyToPlay)) {
-        CMTimeRange seekableRange = [_playerItem.seekableTimeRanges.lastObject CMTimeRangeValue];
-        CMTime relativePosition = CMTimeAdd(position, seekableRange.start);
-        [_playerItem seekToTime:relativePosition toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero completionHandler:completionHandler];
+        NSValue *seekableRange = _playerItem.seekableTimeRanges.lastObject;
+        if (seekableRange) {
+            CMTimeRange range = [seekableRange CMTimeRangeValue];
+            position = CMTimeAdd(position, range.start);
+        }
+        [_playerItem seekToTime:position toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero completionHandler:completionHandler];
     }
 }
 
 - (CMTime)duration {
     NSValue *seekableRange = _playerItem.seekableTimeRanges.lastObject;
     if (seekableRange) {
-        CMTimeRange seekableDuration = [seekableRange CMTimeRangeValue];;
+        CMTimeRange seekableDuration = [seekableRange CMTimeRangeValue];
         return seekableDuration.duration;
     }
     else {

--- a/darwin/Classes/UriAudioSource.m
+++ b/darwin/Classes/UriAudioSource.m
@@ -50,19 +50,36 @@
 
 - (void)seek:(CMTime)position completionHandler:(void (^)(BOOL))completionHandler {
     if (!completionHandler || (_playerItem.status == AVPlayerItemStatusReadyToPlay)) {
-        [_playerItem seekToTime:position toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero completionHandler:completionHandler];
+        CMTimeRange seekableRange = [_playerItem.seekableTimeRanges.lastObject CMTimeRangeValue];
+        CMTime relativePosition = CMTimeAdd(position, seekableRange.start);
+        [_playerItem seekToTime:relativePosition toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero completionHandler:completionHandler];
     }
 }
 
 - (CMTime)duration {
-    return _playerItem.duration;
+    NSValue *seekableRange = _playerItem.seekableTimeRanges.lastObject;
+    if (seekableRange) {
+        CMTimeRange seekableDuration = [seekableRange CMTimeRangeValue];;
+        return seekableDuration.duration;
+    }
+    else {
+        return _playerItem.duration;
+    }
+    return kCMTimeInvalid;
 }
 
 - (void)setDuration:(CMTime)duration {
 }
 
 - (CMTime)position {
-    return _playerItem.currentTime;
+    NSValue *seekableRange = _playerItem.seekableTimeRanges.lastObject;
+    if (seekableRange) {
+        CMTimeRange range = [seekableRange CMTimeRangeValue];
+        return CMTimeSubtract(_playerItem.currentTime, range.start);
+    } else {
+        return _playerItem.currentTime;
+    }
+    
 }
 
 - (CMTime)bufferedPosition {


### PR DESCRIPTION
I found a bug in my last PR.

If we already have a route to an Airplay device, and start playing. The seekableTimeRanges can be empty.
I suspect this is an AppleTV bug, but we should guard still guard against an empty array there.

This implementation only calculates a relative position if we have an object in seekableTimeRanges.

Also one minor fix where i was too enthusiastic typing semicolons.

Tested for two days 👍 