### PR TITLE
[iOS] Solving crashes when audio completes

### DIFF
--- a/darwin/Classes/AudioPlayer.m
+++ b/darwin/Classes/AudioPlayer.m
@@ -367,13 +367,17 @@
 }
 
 - (void)removeItemObservers:(AVPlayerItem *)playerItem {
-    [playerItem removeObserver:self forKeyPath:@"status"];
-    [playerItem removeObserver:self forKeyPath:@"playbackBufferEmpty"];
-    [playerItem removeObserver:self forKeyPath:@"playbackBufferFull"];
-    //[playerItem removeObserver:self forKeyPath:@"playbackLikelyToKeepUp"];
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemDidPlayToEndTimeNotification object:playerItem];
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemFailedToPlayToEndTimeNotification object:playerItem];
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemPlaybackStalledNotification object:playerItem];
+    @try {
+        [playerItem removeObserver:self forKeyPath:@"status"];
+        [playerItem removeObserver:self forKeyPath:@"playbackBufferEmpty"];
+        [playerItem removeObserver:self forKeyPath:@"playbackBufferFull"];
+        //[playerItem removeObserver:self forKeyPath:@"playbackLikelyToKeepUp"];
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemDidPlayToEndTimeNotification object:playerItem];
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemFailedToPlayToEndTimeNotification object:playerItem];
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemPlaybackStalledNotification object:playerItem];
+    } @catch (id exception) {
+        NSLog(@"Tried to remove an observer for a key that did not have one");
+    }
 }
 
 - (void)addItemObservers:(AVPlayerItem *)playerItem {


### PR DESCRIPTION
Given the plugin architecture, `removeItemObservers` might be called twice for the same `playerItem` (when it gets completed in a queue and when the audio plugin is disposed).

This PR fixes the crash that is happening in this scenario.