### PR TITLE
Add web dependency

### DIFF
--- a/just_audio/CHANGELOG.md
+++ b/just_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4+1
+
+* Add web dependency.
+
 ## 0.5.4
 
 * Use audio_session 0.0.9.

--- a/just_audio/README.md
+++ b/just_audio/README.md
@@ -232,19 +232,6 @@ If you wish to connect to non-HTTPS URLS, add the following to your `Info.plist`
 </dict>
 ```
 
-### Web
-
-Add the package [just_audio_web](https://github.com/ryanheise/just_audio/tree/master/just_audio_web) to the `dependencies` of your `pubspec.yaml` in addition to just_audio:
-
-```yaml
-...
-dependencies:
-  ...
-  just_audio: ...
-  just_audio_web: ...
-  ...
-```
-
 ## Related plugins
 
 * [audio_service](https://pub.dev/packages/audio_service): play any audio in the background and control playback from the lock screen, Android notifications, the iOS Control Center, and headset buttons.

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: Flutter plugin to play audio from streams, files, assets, DASH/HLS streams and playlists. Works with audio_service to play audio in the background.
-version: 0.5.4
+version: 0.5.4+1
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio
 
 environment:
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   just_audio_platform_interface: ^1.1.0
+  just_audio_web: ^0.1.0
   audio_session: ^0.0.9
   rxdart: ^0.24.1
   path: ^1.6.4


### PR DESCRIPTION
If you look at federated plugins, e.g. https://github.com/creativecreatorormaybenot/wakelock or `video_player`, you will see that they add their `web` dependency to the main plugin in their own Pubspec.