### PR TITLE
Fixed ExoPlayer's seeking with proxy enabled

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1035,6 +1035,7 @@ class _ProxyHttpServer {
           originResponse.headers.forEach((name, value) {
             request.response.headers.set(name, value);
           });
+          request.response.statusCode = originResponse.statusCode;
 
           // Pipe response
           await originResponse.pipe(request.response);


### PR DESCRIPTION
First of all, thanks again for your efforts in developing and maintaining this lib. You rock!

While working on my caching proxy (basically just copying what you did and adding my own features) I noticed that when I'm trying to seek outside of the buffered part it won't finish loading/buffering and then just next item starts playing. In fact, ExoPlayer retries the same request for a couple of times and then throws EOFException.

Demo app repro steps:
1. Add headers to each AudioSource
2. Launch app
3. Play third playlist item
4. Click/tap on 1/3 of the seek bar, then click/tap on 2/3 of the bar
5. It just keeps buffering

In my app I also see EOFException in Debug Console and next item starts playing.

The reason was wrong HTTP status code. As ExoPlayer uses [range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) it expects to get `206 Partial Content` when requesting part of a file but proxy always sends 200s and it confuses ExoPlayer. 

Fixed by forwarding HTTP status code from original request.