### PR TITLE
Fix SequenceState's currentSource & currentIndex when length is zero

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -129,7 +129,7 @@ class AudioPlayer {
       (sequence, shuffleIndices, currentIndex, shuffleModeEnabled, loopMode) {
         if (sequence == null) return null;
         if (currentIndex == null) currentIndex = 0;
-        currentIndex = min(sequence.length - 1, max(0, currentIndex));
+        currentIndex = max(min(sequence.length - 1, max(0, currentIndex)), 0);
         return SequenceState(
           sequence,
           currentIndex,
@@ -1310,7 +1310,8 @@ class SequenceState {
       this.shuffleModeEnabled, this.loopMode);
 
   /// The current source in the sequence.
-  IndexedAudioSource get currentSource => sequence[currentIndex];
+  IndexedAudioSource get currentSource =>
+      sequence.isEmpty ? null : sequence[currentIndex];
 
   /// The effective sequence. This is equivalent to [sequence]. If
   /// [shuffleModeEnabled] is true, this is modulated by [shuffleIndices].


### PR DESCRIPTION
When a `ConcatenatingAudioSource` has a length of 0 (such as after calling `clear()`), accessing the `SequenceState. currentSource` getter throws an index out of range exception.

Furthermore, `SequenceState`'s docs state that `If [sequence.length] is 0, then [currentIndex] is also 0.`. However, `currentIndex` is currently getting set to `-1` when `sequence.length` is 0.

This PR fixes both issues.