### PR TITLE
supports cronet

### DIFF
--- a/just_audio/android/build.gradle
+++ b/just_audio/android/build.gradle
@@ -44,4 +44,6 @@ dependencies {
     implementation 'com.google.android.exoplayer:exoplayer-dash:2.13.1'
     implementation 'com.google.android.exoplayer:exoplayer-hls:2.13.1'
     implementation 'com.google.android.exoplayer:exoplayer-smoothstreaming:2.13.1'
+    implementation 'com.google.android.exoplayer:extension-cronet:2.13.1'
+    implementation 'com.google.android.gms:play-services-cronet:17.0.0'
 }

--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
@@ -29,9 +29,9 @@ import com.google.android.exoplayer2.source.dash.DashMediaSource;
 import com.google.android.exoplayer2.source.hls.HlsMediaSource;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.upstream.DataSource;
-import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
-import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
-import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
+import com.google.android.exoplayer2.ext.cronet.CronetDataSource;
+import com.google.android.exoplayer2.ext.cronet.CronetDataSourceFactory;
+import com.google.android.exoplayer2.ext.cronet.CronetEngineWrapper;
 import com.google.android.exoplayer2.util.MimeTypes;
 import com.google.android.exoplayer2.util.Util;
 import io.flutter.Log;
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.Executors;
 
 public class AudioPlayer implements MethodCallHandler, Player.EventListener, AudioListener, MetadataOutput {
 
@@ -494,13 +495,8 @@ public class AudioPlayer implements MethodCallHandler, Player.EventListener, Aud
 
     private DataSource.Factory buildDataSourceFactory() {
         String userAgent = Util.getUserAgent(context, "just_audio");
-        DataSource.Factory httpDataSourceFactory = new DefaultHttpDataSourceFactory(
-                userAgent,
-                DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
-                DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
-                true
-        );
-        return new DefaultDataSourceFactory(context, httpDataSourceFactory);
+        CronetEngineWrapper wrapper = new CronetEngineWrapper(context, userAgent, false);
+        return new CronetDataSource.Factory(wrapper, Executors.newSingleThreadExecutor());
     }
 
     private void load(final MediaSource mediaSource, final long initialPosition, final Integer initialIndex, final Result result) {


### PR DESCRIPTION
We should be using cronet for streaming use cases, it will fail and respond much faster than OkHttp. I am not sure what we would have to do to support Apple with this, but I know it is possible. Exoplayer does make this easier on android though from what I can tell. This will also give us support for HTTP3/QUIC if the server supports, but Cronet falls back to http 1.1 fine in my tests.