### PR TITLE
Catch errors from audioElement.play()

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -808,8 +808,14 @@ class AudioPlayer {
 
   Future<void> _sendPlayRequest(
       AudioPlayerPlatform platform, Completer<void>? playCompleter) async {
-    await platform.play(PlayRequest());
-    playCompleter?.complete();
+    try
+    {
+      await platform.play(PlayRequest());
+      playCompleter?.complete();
+    }
+    catch (e) {
+      playCompleter?.completeError(e);
+    }
   }
 
   /// Stops playing audio and releases decoders and other native platform

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -564,7 +564,7 @@ abstract class UriAudioSourcePlayer extends IndexedAudioSourcePlayer {
   @override
   Future<void> play() async {
     _audioElement.currentTime = _resumePos!;
-    _audioElement.play();
+    await _audioElement.play();
     _completer = Completer<dynamic>();
     await _completer!.future;
     _completer = null;


### PR DESCRIPTION
HTMLMediaElement.play() returns a promise which is resolved when
playback has been started, or is rejected if for any reason playback
cannot be started.

Possible errors include:

NotAllowedError: The user agent (browser) or operating system doesn't
allow playback of media in the current context or situation. This may
happen, for example, if the browser requires the user to explicitly
start media playback by clicking a "play" button.

NotSupportedError: The media source (which may be specified as a
MediaStream, MediaSource, Blob, or File, for example) doesn't represent
a supported media format.