### PR TITLE
Fix timers

### DIFF
--- a/just_audio/example/test/widget_test.dart
+++ b/just_audio/example/test/widget_test.dart
@@ -11,15 +11,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:just_audio_example/main.dart';
 
 void main() {
-  testWidgets('Verify Platform version', (WidgetTester tester) async {
+  testWidgets('Verify Playlist', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(MyApp());
 
-    // Verify that platform version is retrieved.
     expect(
       find.byWidgetPredicate(
-        (Widget widget) => widget is Text &&
-                           widget.data!.startsWith('Running on:'),
+        (Widget widget) =>
+            widget is Text && widget.data!.startsWith('Playlist'),
       ),
       findsOneWidget,
     );

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -494,7 +494,7 @@ class AudioPlayer {
       return s;
     }
 
-    Timer currentTimer;
+    Timer? currentTimer;
     StreamSubscription? durationSubscription;
     StreamSubscription? playbackEventSubscription;
     void yieldPosition(Timer timer) {
@@ -515,9 +515,8 @@ class AudioPlayer {
       controller.add(position);
     }
 
-    currentTimer = Timer.periodic(step(), yieldPosition);
     durationSubscription = durationStream.listen((duration) {
-      currentTimer.cancel();
+      currentTimer?.cancel();
       currentTimer = Timer.periodic(step(), yieldPosition);
     }, onError: (Object e, StackTrace stackTrace) {});
     playbackEventSubscription = playbackEventStream.listen((event) {

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1003,7 +1003,8 @@ class AudioPlayer {
     final currentIndex = this.currentIndex;
     final audioSource = _audioSource;
     final durationCompleter = Completer<Duration?>();
-    _platform = Future<AudioPlayerPlatform>(() async {
+
+    Future<AudioPlayerPlatform> setPlatform() async {
       _playbackEventSubscription?.cancel();
       if (!force) {
         final oldPlatform = await oldPlatformFuture!;
@@ -1097,7 +1098,9 @@ class AudioPlayer {
       }
 
       return platform;
-    });
+    }
+
+    _platform = setPlatform();
     return durationCompleter.future;
   }
 

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -512,7 +512,9 @@ class AudioPlayer {
         controller.close();
         return;
       }
-      controller.add(position);
+      if (playing) {
+        controller.add(position);
+      }
     }
 
     durationSubscription = durationStream.listen((duration) {

--- a/just_audio/test/just_audio_test.dart
+++ b/just_audio/test/just_audio_test.dart
@@ -965,6 +965,12 @@ void runTests() {
     final duration3 = Duration(milliseconds: 750);
 
     await player.seek(duration1);
+    expectState(
+      player: player,
+      position: duration1,
+      processingState: ProcessingState.ready,
+      playing: false,
+    );
     completer = Completer<dynamic>();
     subscription = player.positionStream.listen((position) {
       expectDuration(position, duration1);
@@ -975,6 +981,12 @@ void runTests() {
 
     player.play();
     await Future<dynamic>.delayed(duration2);
+    expectState(
+      player: player,
+      position: duration1 + duration2,
+      processingState: ProcessingState.ready,
+      playing: true,
+    );
     await player.pause();
     completer = Completer<dynamic>();
     subscription = player.positionStream.listen((position) {
@@ -985,6 +997,12 @@ void runTests() {
     await completer.future;
 
     await player.seek(duration1 + duration2 + duration3);
+    expectState(
+      player: player,
+      position: duration1 + duration2 + duration3,
+      processingState: ProcessingState.ready,
+      playing: false,
+    );
     completer = Completer<dynamic>();
     subscription = player.positionStream.listen((position) {
       expectDuration(position, duration1 + duration2 + duration3);


### PR DESCRIPTION
There were two `!timersPending` issues found during `flutter test`. The first one could be resolved by removing one of the `Timer` instantiations, which was deemed redundant. In this course it became necessary to declare `currentTimer` nullable. To do justice to the doc description, the stream now only emits while the player is playing.

Refactoring a function within `_setPlatformActive` then settled the second error.

The test was also adjusted to find a reasonable widget.

Attempted fix to https://github.com/ryanheise/just_audio/issues/356