### PR TITLE
Fix error handling on play without load

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1241,7 +1241,10 @@ class AudioPlayer {
             _playbackEvent.processingState == ProcessingState.idle) {
           _setPlatformActive(false)?.catchError((dynamic e) {});
         }
-      }, onError: _playbackEventSubject.addError);
+      }, onError: (Object e) {
+        _playbackEventSubject.addError(e);
+        _setPlatformActive(false)?.catchError((dynamic e) {});
+      });
     }
 
     Future<AudioPlayerPlatform> setPlatform() async {
@@ -1353,7 +1356,6 @@ class AudioPlayer {
           if (checkInterruption()) return platform;
           durationCompleter.complete(duration);
         } catch (e, stackTrace) {
-          await _setPlatformActive(false)?.catchError((dynamic e) {});
           durationCompleter.completeError(e, stackTrace);
         }
       } else {


### PR DESCRIPTION
When play without load like below, no error reported from native platform.
```
final player = AudioPlayer();
await player.setAudioSource(<NotFoundAudioSource>, preload = false);
player.playbackEventStream.listen((d) => print('data: $d'), onError: (e) => print('error: $e'));
await player.play();
// should print 'error: PlatformException(...)' after play, but it doesn't.
```

This is because before playbackEventStream reports error, platform is deactivated and the stream  is canceled.
The deactivation is caused by error handling on duration report logic in setPlatform.
https://github.com/ryanheise/just_audio/blob/2a22b69db6e7696a615c96ecf456d42022d41894/just_audio/lib/just_audio.dart#L1356

Also fixed stuck in playing after such error occurs.

ref #390