### PR TITLE
HLS Headers Now Working

### DIFF
--- a/just_audio/CHANGELOG.md
+++ b/just_audio/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.15
+* Add header capability for HLS audio sources.
+
 ## 0.9.14
 
 * Fix bug when pausing/stopping quickly after play.

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1917,7 +1917,7 @@ class _ProxyHttpServer {
   
   /// Adds a handler for a subsequent uri (such as in the case of HLS stream
   /// fragments) to the handler map.
-  Uri subsequentUri(Uri uri) {
+  Uri addSubsequentUri(Uri uri) {
     var newUri = uri.replace(
       scheme: scheme,
       host: host,

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and concatenate any sound from any source (asset/file/URL/stream) in a variety of audio formats with gapless playback.
-version: 0.9.14
+version: 0.9.15
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio
 
 environment:


### PR DESCRIPTION
HTTP proxy now adds headers to each subsequent GET request for audio fragments when using HLSAudioSources.
Null check operator no longer causing unhandled exception when headers are set for HLSAudioSource. Resolves #470