### PR TITLE
feat: add index seeking option for android progressive audio source

### DIFF
--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
@@ -22,6 +22,8 @@ import com.google.android.exoplayer2.Player.PositionInfo;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.audio.AudioAttributes;
+import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
+import com.google.android.exoplayer2.extractor.mp3.Mp3Extractor;
 import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.android.exoplayer2.metadata.MetadataOutput;
 import com.google.android.exoplayer2.metadata.icy.IcyHeaders;
@@ -587,8 +589,15 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
         String id = (String)map.get("id");
         switch ((String)map.get("type")) {
         case "progressive":
-            return new ProgressiveMediaSource.Factory(buildDataSourceFactory())
-                    .createMediaSource(new MediaItem.Builder()
+            ProgressiveMediaSource.Factory factory;
+            if ((Boolean)map.get("androidIndexSeeking")) {
+                DefaultExtractorsFactory extractorsFactory = new DefaultExtractorsFactory()
+                        .setMp3ExtractorFlags(Mp3Extractor.FLAG_ENABLE_INDEX_SEEKING);
+                factory = new ProgressiveMediaSource.Factory(buildDataSourceFactory(), extractorsFactory);
+            } else {
+                factory = new ProgressiveMediaSource.Factory(buildDataSourceFactory());
+            }
+            return factory.createMediaSource(new MediaItem.Builder()
                             .setUri(Uri.parse((String)map.get("uri")))
                             .setTag(id)
                             .build());

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -2160,14 +2160,19 @@ abstract class UriAudioSource extends IndexedAudioSource {
 ///
 /// If headers are set, just_audio will create a cleartext local HTTP proxy on
 /// your device to forward HTTP requests with headers included.
+///
+/// If androidIndexSeeking is ture, set FLAG_ENABLE_INDEX_SEEKING is used for
+/// exact but slow seeking. (only Android)
 class ProgressiveAudioSource extends UriAudioSource {
+  bool androidIndexSeeking;
+
   ProgressiveAudioSource(Uri uri,
-      {Map<String, String>? headers, dynamic tag, Duration? duration})
+      {Map<String, String>? headers, dynamic tag, Duration? duration, bool this.androidIndexSeeking = false})
       : super(uri, headers: headers, tag: tag, duration: duration);
 
   @override
   AudioSourceMessage _toMessage() => ProgressiveAudioSourceMessage(
-      id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
+      id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag, androidIndexSeeking: androidIndexSeeking);
 }
 
 /// An [AudioSource] representing a DASH stream. The following URI schemes are

--- a/just_audio_platform_interface/lib/just_audio_platform_interface.dart
+++ b/just_audio_platform_interface/lib/just_audio_platform_interface.dart
@@ -1020,11 +1020,14 @@ abstract class UriAudioSourceMessage extends IndexedAudioSourceMessage {
 /// Information about a progressive audio source to be communicated with the
 /// platform implementation.
 class ProgressiveAudioSourceMessage extends UriAudioSourceMessage {
+  final bool androidIndexSeeking;
+
   ProgressiveAudioSourceMessage({
     required String id,
     required String uri,
     Map<String, String>? headers,
     dynamic tag,
+    bool this.androidIndexSeeking = false,
   }) : super(id: id, uri: uri, headers: headers, tag: tag);
 
   @override
@@ -1033,6 +1036,7 @@ class ProgressiveAudioSourceMessage extends UriAudioSourceMessage {
         'id': id,
         'uri': uri,
         'headers': headers,
+        'androidIndexSeeking': androidIndexSeeking,
       };
 }
 


### PR DESCRIPTION
ref #650

This PR adds index seeking option to progressive audio source.

Add an option named `androidIndexSeeking` to `ProgressiveAudioSource`.
To use it after auto detection (like `AudioSource.uri`), it is revealed an instance variable.

usage
```
# if we know it's ProgressiveAudioSource
final progressiveAudioSource = ProgressiveAudioSource(audioUri, androidIndexSeeking: true);

# if we do not know it's ProgressiveAudioSource
final source = AudioSource.uri(audioUri);
if (source is ProgressiveAudioSource) {
  source.androidIndexSeeking = true;
}
```