### PR TITLE
fix: update loaded audio source position

### DIFF
--- a/just_audio/darwin/Classes/AudioPlayer.m
+++ b/just_audio/darwin/Classes/AudioPlayer.m
@@ -578,7 +578,6 @@
     }
     _loadResult = result;
     _processingState = loading;
-    [self updatePosition];
     _index = (initialIndex != (id)[NSNull null]) ? [initialIndex intValue] : 0;
     // Remove previous observers
     if (_indexedAudioSources) {
@@ -628,6 +627,7 @@
         [self addItemObservers:source.playerItem];
         source.playerItem.audioSource = source;
     }
+    [self updatePosition];
     [self updateOrder];
     // Set up an empty player
     if (!_player) {


### PR DESCRIPTION
fixed #656

`updatePosition` in load seems too early. At this moment, it will update former audio source position and report it.
This PR moves `updatePosition` to a later line to report new audio source position.
(If initial position is set, it will be reported right after attached)