### PR TITLE
Add MappingAudioSource for just-in-time audio source creation

### DIFF
--- a/just_audio/README.md
+++ b/just_audio/README.md
@@ -399,6 +399,7 @@ Please also consider pressing the thumbs up button at the top of [this page](htt
 | looping/shuffling              | ✅      | ✅  | ✅    | ✅  | ✅      | ✅    |
 | compose audio                  | ✅      | ✅  | ✅    | ✅  |         | ✅    |
 | gapless playback               | ✅      | ✅  | ✅    |     | ✅      | ✅    |
+| mapping audio sources          | ✅      |     |       | ✅  |         |       |
 | report player errors           | ✅      | ✅  | ✅    | ✅  | ✅      | ✅    |
 | handle phonecall interruptions | ✅      | ✅  |       |     |         |       |
 | buffering/loading options      | ✅      | ✅  | ✅    |     |         |       |

--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
@@ -713,7 +713,7 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
             methodChannel.invokeMethod("createMappedAudioSourceSource", Collections.singletonMap("id", id), new Result() {
                 @Override
                 public void success(Object json) {
-                    final MediaSource mediaSource = decodeAudioSource(json);
+                    final MediaSource mediaSource = json == null ? null : decodeAudioSource(json);
                     receiver.onMediaSourceCreated(mediaSource);
                 }
 

--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/LazyMediaSource.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/LazyMediaSource.java
@@ -1,0 +1,160 @@
+package com.ryanheise.just_audio;
+
+import android.os.Handler;
+
+import com.google.android.exoplayer2.MediaItem;
+import com.google.android.exoplayer2.Timeline;
+import com.google.android.exoplayer2.analytics.PlayerId;
+import com.google.android.exoplayer2.drm.DrmSessionEventListener;
+import com.google.android.exoplayer2.source.MediaPeriod;
+import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.MediaSourceEventListener;
+import com.google.android.exoplayer2.upstream.Allocator;
+import com.google.android.exoplayer2.upstream.TransferListener;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A {@link MediaSource} that lazily defers to another {@link MediaSource} when it is required.
+ * <p>
+ * This {@link MediaSource} must be used with a {@link com.google.android.exoplayer2.source.MaskingMediaSource}.
+ */
+class LazyMediaSource implements MediaSource {
+    private final LazyMediaSourceProvider mediaSourceProvider;
+    public final String id;
+    public final MediaItem placeholderMediaItem;
+
+    private final Map<MediaSourceEventListener, Handler> pendingEventListeners = new HashMap<>();
+    private final Map<DrmSessionEventListener, Handler> pendingDrmEventListeners = new HashMap<>();
+
+    private MediaSource mediaSource;
+
+    LazyMediaSource(LazyMediaSourceProvider mediaSourceProvider, String id, MediaItem placeholderMediaItem) {
+        this.mediaSourceProvider = mediaSourceProvider;
+        this.id = id;
+        this.placeholderMediaItem = placeholderMediaItem;
+    }
+
+    @Override
+    public void addEventListener(Handler handler, MediaSourceEventListener eventListener) {
+        if (mediaSource == null) {
+            pendingEventListeners.put(eventListener, handler);
+        } else {
+            mediaSource.addEventListener(handler, eventListener);
+        }
+    }
+
+    @Override
+    public void removeEventListener(MediaSourceEventListener eventListener) {
+        if (mediaSource == null) {
+            pendingEventListeners.remove(eventListener);
+        } else {
+            mediaSource.removeEventListener(eventListener);
+        }
+    }
+
+    @Override
+    public void addDrmEventListener(Handler handler, DrmSessionEventListener eventListener) {
+        if (mediaSource == null) {
+            pendingDrmEventListeners.put(eventListener, handler);
+        } else {
+            mediaSource.addDrmEventListener(handler, eventListener);
+        }
+    }
+
+    @Override
+    public void removeDrmEventListener(DrmSessionEventListener eventListener) {
+        if (mediaSource == null) {
+            pendingDrmEventListeners.remove(eventListener);
+        } else {
+            mediaSource.removeDrmEventListener(eventListener);
+        }
+    }
+
+    @Override
+    public Timeline getInitialTimeline() {
+        if (mediaSource == null) return null;
+        return mediaSource.getInitialTimeline();
+    }
+
+    @Override
+    public boolean isSingleWindow() {
+        if (mediaSource == null) return false;
+        return mediaSource.isSingleWindow();
+    }
+
+    @Override
+    public MediaItem getMediaItem() {
+        if (mediaSource == null) {
+            return placeholderMediaItem;
+        } else {
+            return mediaSource.getMediaItem();
+        }
+    }
+
+    @Override
+    public void prepareSource(
+            MediaSourceCaller caller,
+            TransferListener mediaTransferListener,
+            PlayerId playerId
+    ) {
+        mediaSourceProvider.createMediaSource(id, (mediaSource) -> {
+            this.mediaSource = mediaSource;
+            for (Map.Entry<MediaSourceEventListener, Handler> entry : pendingEventListeners.entrySet()) {
+                mediaSource.addEventListener(entry.getValue(), entry.getKey());
+            }
+            pendingEventListeners.clear();
+            for (Map.Entry<DrmSessionEventListener, Handler> entry : pendingDrmEventListeners.entrySet()) {
+                mediaSource.addDrmEventListener(entry.getValue(), entry.getKey());
+            }
+            pendingDrmEventListeners.clear();
+            mediaSource.prepareSource(caller, mediaTransferListener, playerId);
+        });
+    }
+
+    @Override
+    public void maybeThrowSourceInfoRefreshError() throws IOException {
+        if (mediaSource == null) return;
+        mediaSource.maybeThrowSourceInfoRefreshError();
+    }
+
+    @Override
+    public void enable(MediaSourceCaller caller) {
+        if (mediaSource == null) throw new IllegalStateException();
+        mediaSource.enable(caller);
+    }
+
+    @Override
+    public MediaPeriod createPeriod(MediaPeriodId id, Allocator allocator, long startPositionUs) {
+        if (mediaSource == null) throw new IllegalStateException();
+        return mediaSource.createPeriod(id, allocator, startPositionUs);
+    }
+
+    @Override
+    public void releasePeriod(MediaPeriod mediaPeriod) {
+        if (mediaSource == null) throw new IllegalStateException();
+        mediaSource.releasePeriod(mediaPeriod);
+    }
+
+    @Override
+    public void disable(MediaSourceCaller caller) {
+        if (mediaSource == null) throw new IllegalStateException();
+        mediaSource.disable(caller);
+    }
+
+    @Override
+    public void releaseSource(MediaSourceCaller caller) {
+        if (mediaSource == null) return;
+        mediaSource.releaseSource(caller);
+    }
+}
+
+interface LazyMediaSourceReceiver {
+    void onMediaSourceCreated(MediaSource mediaSource);
+}
+
+interface LazyMediaSourceProvider {
+    void createMediaSource(String id, LazyMediaSourceReceiver receiver);
+}

--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/LazyMediaSource.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/LazyMediaSource.java
@@ -9,6 +9,7 @@ import com.google.android.exoplayer2.drm.DrmSessionEventListener;
 import com.google.android.exoplayer2.source.MediaPeriod;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.MediaSourceEventListener;
+import com.google.android.exoplayer2.source.SilenceMediaSource;
 import com.google.android.exoplayer2.upstream.Allocator;
 import com.google.android.exoplayer2.upstream.TransferListener;
 
@@ -101,16 +102,21 @@ class LazyMediaSource implements MediaSource {
             PlayerId playerId
     ) {
         mediaSourceProvider.createMediaSource(id, (mediaSource) -> {
-            this.mediaSource = mediaSource;
+            if (mediaSource == null) {
+                this.mediaSource = new SilenceMediaSource(0);
+            } else {
+                this.mediaSource = mediaSource;
+            }
+
             for (Map.Entry<MediaSourceEventListener, Handler> entry : pendingEventListeners.entrySet()) {
-                mediaSource.addEventListener(entry.getValue(), entry.getKey());
+                this.mediaSource.addEventListener(entry.getValue(), entry.getKey());
             }
             pendingEventListeners.clear();
             for (Map.Entry<DrmSessionEventListener, Handler> entry : pendingDrmEventListeners.entrySet()) {
-                mediaSource.addDrmEventListener(entry.getValue(), entry.getKey());
+                this.mediaSource.addDrmEventListener(entry.getValue(), entry.getKey());
             }
             pendingDrmEventListeners.clear();
-            mediaSource.prepareSource(caller, mediaTransferListener, playerId);
+            this.mediaSource.prepareSource(caller, mediaTransferListener, playerId);
         });
     }
 

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1329,6 +1329,11 @@ class AudioPlayer {
       final platform = active
           ? await (_nativePlatform = _pluginPlatform.init(InitRequest(
               id: _id,
+              getAudioSourceMessage: (id) {
+                assert(_audioSources.containsKey(id),
+                    'Audio source with ID $id does not exist!');
+                return _audioSources[id]!._toMessage();
+              },
               audioLoadConfiguration: _audioLoadConfiguration?._toMessage(),
               androidAudioEffects: (_isAndroid() || _isUnitTest())
                   ? _audioPipeline.androidAudioEffects

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -2324,8 +2324,24 @@ class SilenceAudioSource extends IndexedAudioSource {
       SilenceAudioSourceMessage(id: _id, duration: duration);
 }
 
+/// An [AudioSource] that maps to another [AudioSource] when it is first loaded.
+///
+/// This is useful, for example, inside a [ConcatenatingAudioSource], if an
+/// audio URL cannot be loaded until just before it is played.
+///
+/// Note that [AudioSource]s are not currently disposed of until the
+/// [AudioPlayer] completes. It is recommended to keep the [identifier] and
+/// [createAudioSource] values light - the [identifier], for example, could be a
+/// basic [Object] that points to a value in a map stored elsewhere.
+///
+/// NOTE: This is currently supported on Android and the Web only.
 class MappingAudioSource<T> extends IndexedAudioSource {
+  /// An identifier representing the [AudioSource] to be created.
   final T identifier;
+
+  /// A function that creates the [AudioSource] to be played.
+  ///
+  /// If `null` is returned, a silent, instant sound will be used instead.
   final Future<IndexedAudioSource?> Function(T identifier) createAudioSource;
 
   MappingAudioSource(

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -2353,10 +2353,14 @@ class MappingAudioSource<T> extends IndexedAudioSource {
   })  : assert(supportedOnCurrentPlatform),
         super(tag: tag, duration: duration);
 
+  Future<IndexedAudioSource?>? _audioSourceFuture;
+
   @override
   IndexedAudioSourceMessage _toMessage() => MappingAudioSourceMessage(
         id: _id,
-        createAudioSourceMessage: () => createAudioSource(identifier)
+        createAudioSourceMessage: () => (_audioSourceFuture ??=
+                createAudioSource(identifier).then((audioSource) =>
+                    audioSource?._setup(_player!).then((_) => audioSource)))
             .then((audioSource) => audioSource?._toMessage()),
       );
 

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -2336,7 +2336,7 @@ class MappingAudioSource<T> extends IndexedAudioSource {
   }) : super(tag: tag, duration: duration);
 
   @override
-  IndexedAudioSourceMessage _toMessage() => MappingAudioSourceMessage<T>(
+  IndexedAudioSourceMessage _toMessage() => MappingAudioSourceMessage(
         id: _id,
         createAudioSourceMessage: () => createAudioSource(identifier)
             .then((audioSource) => audioSource?._toMessage()),

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -2334,7 +2334,8 @@ class SilenceAudioSource extends IndexedAudioSource {
 /// [createAudioSource] values light - the [identifier], for example, could be a
 /// basic [Object] that points to a value in a map stored elsewhere.
 ///
-/// NOTE: This is currently supported on Android and the Web only.
+/// NOTE: This is officially supported on Android and the Web only. Check
+/// [supportedOnCurrentPlatform] before using.
 class MappingAudioSource<T> extends IndexedAudioSource {
   /// An identifier representing the [AudioSource] to be created.
   final T identifier;
@@ -2349,7 +2350,8 @@ class MappingAudioSource<T> extends IndexedAudioSource {
     this.createAudioSource, {
     dynamic tag,
     Duration? duration,
-  }) : super(tag: tag, duration: duration);
+  })  : assert(supportedOnCurrentPlatform),
+        super(tag: tag, duration: duration);
 
   @override
   IndexedAudioSourceMessage _toMessage() => MappingAudioSourceMessage(
@@ -2357,6 +2359,9 @@ class MappingAudioSource<T> extends IndexedAudioSource {
         createAudioSourceMessage: () => createAudioSource(identifier)
             .then((audioSource) => audioSource?._toMessage()),
       );
+
+  static bool get supportedOnCurrentPlatform =>
+      JustAudioPlatform.instance.supportsMappingAudioSource;
 }
 
 /// An [AudioSource] representing a concatenation of multiple audio sources to

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -2326,7 +2326,7 @@ class SilenceAudioSource extends IndexedAudioSource {
 
 class MappingAudioSource<T> extends IndexedAudioSource {
   final T identifier;
-  final Future<IndexedAudioSource> Function(T identifier) createAudioSource;
+  final Future<IndexedAudioSource?> Function(T identifier) createAudioSource;
 
   MappingAudioSource(
     this.identifier,
@@ -2339,7 +2339,7 @@ class MappingAudioSource<T> extends IndexedAudioSource {
   IndexedAudioSourceMessage _toMessage() => MappingAudioSourceMessage<T>(
         id: _id,
         createAudioSourceMessage: () => createAudioSource(identifier)
-            .then((audioSource) => audioSource._toMessage()),
+            .then((audioSource) => audioSource?._toMessage()),
       );
 }
 

--- a/just_audio_platform_interface/lib/just_audio_platform_interface.dart
+++ b/just_audio_platform_interface/lib/just_audio_platform_interface.dart
@@ -1130,7 +1130,7 @@ class SilenceAudioSourceMessage extends IndexedAudioSourceMessage {
 
 /// Information about a mapping audio source to be communicated with the
 /// platform implementation.
-class MappingAudioSourceMessage<T> extends IndexedAudioSourceMessage {
+class MappingAudioSourceMessage extends IndexedAudioSourceMessage {
   /// The closure can only be used by platform implementations that pass by
   /// reference.
   final Future<IndexedAudioSourceMessage?> Function() createAudioSourceMessage;

--- a/just_audio_platform_interface/lib/just_audio_platform_interface.dart
+++ b/just_audio_platform_interface/lib/just_audio_platform_interface.dart
@@ -1116,6 +1116,26 @@ class SilenceAudioSourceMessage extends IndexedAudioSourceMessage {
       };
 }
 
+/// Information about a mapping audio source to be communicated with the
+/// platform implementation.
+class MappingAudioSourceMessage<T> extends IndexedAudioSourceMessage {
+  /// The closure can only be used by platform implementations that pass by
+  /// reference.
+  final Future<IndexedAudioSourceMessage> Function() createAudioSourceMessage;
+
+  MappingAudioSourceMessage({
+    required String id,
+    required this.createAudioSourceMessage,
+    dynamic tag,
+  }) : super(id: id, tag: tag);
+
+  @override
+  Map<dynamic, dynamic> toMap() => <dynamic, dynamic>{
+        'type': 'mapping',
+        'id': id,
+      };
+}
+
 /// Information about a concatenating audio source to be communicated with the
 /// platform implementation.
 class ConcatenatingAudioSourceMessage extends AudioSourceMessage {

--- a/just_audio_platform_interface/lib/just_audio_platform_interface.dart
+++ b/just_audio_platform_interface/lib/just_audio_platform_interface.dart
@@ -63,8 +63,12 @@ abstract class JustAudioPlatform extends PlatformInterface {
 /// [AudioPlayerPlatform] methods.
 abstract class AudioPlayerPlatform {
   final String id;
+  final AudioSourceMessageGetter getAudioSourceMessage;
 
-  AudioPlayerPlatform(this.id);
+  AudioPlayerPlatform(
+    this.id, {
+    this.getAudioSourceMessage = _unimplementedGetAudioServiceMessage,
+  });
 
   /// A broadcast stream of playback events.
   Stream<PlaybackEventMessage> get playbackEventMessageStream {
@@ -222,7 +226,13 @@ abstract class AudioPlayerPlatform {
     throw UnimplementedError(
         "androidEqualizerBandSetGain() has not been implemented.");
   }
+
+  static Never _unimplementedGetAudioServiceMessage(String id) =>
+      throw UnimplementedError(
+          'getAudioServiceMessage() has not been implemented.');
 }
+
+typedef AudioSourceMessageGetter = AudioSourceMessage Function(String id);
 
 /// A data update communicated from the platform implementation to the Flutter
 /// plugin. Each field should trigger a state update in the frontend plugin if
@@ -385,6 +395,7 @@ class IcyHeadersMessage {
 /// player instance.
 class InitRequest {
   final String id;
+  AudioSourceMessageGetter getAudioSourceMessage;
   final AudioLoadConfigurationMessage? audioLoadConfiguration;
   final List<AudioEffectMessage> androidAudioEffects;
   final List<AudioEffectMessage> darwinAudioEffects;
@@ -392,6 +403,7 @@ class InitRequest {
 
   InitRequest({
     required this.id,
+    required this.getAudioSourceMessage,
     this.audioLoadConfiguration,
     this.androidAudioEffects = const [],
     this.darwinAudioEffects = const [],

--- a/just_audio_platform_interface/lib/just_audio_platform_interface.dart
+++ b/just_audio_platform_interface/lib/just_audio_platform_interface.dart
@@ -34,6 +34,9 @@ abstract class JustAudioPlatform extends PlatformInterface {
     _instance = instance;
   }
 
+  /// True if the platform can handle [MappingAudioSourceMessage]s.
+  bool get supportsMappingAudioSource => false;
+
   /// Creates a new platform player and returns a nested platform interface for
   /// communicating with that player.
   Future<AudioPlayerPlatform> init(InitRequest request) {

--- a/just_audio_platform_interface/lib/just_audio_platform_interface.dart
+++ b/just_audio_platform_interface/lib/just_audio_platform_interface.dart
@@ -1133,7 +1133,7 @@ class SilenceAudioSourceMessage extends IndexedAudioSourceMessage {
 class MappingAudioSourceMessage<T> extends IndexedAudioSourceMessage {
   /// The closure can only be used by platform implementations that pass by
   /// reference.
-  final Future<IndexedAudioSourceMessage> Function() createAudioSourceMessage;
+  final Future<IndexedAudioSourceMessage?> Function() createAudioSourceMessage;
 
   MappingAudioSourceMessage({
     required String id,

--- a/just_audio_platform_interface/lib/method_channel_just_audio.dart
+++ b/just_audio_platform_interface/lib/method_channel_just_audio.dart
@@ -1,12 +1,20 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 
 import 'just_audio_platform_interface.dart';
 
 /// An implementation of [JustAudioPlatform] that uses method channels.
+///
+/// For third-party platform implementations, be sure to extend this class and
+/// override supported feature flags like [supportsMappingAudioSource] to fit
+/// the supported feature set.
 class MethodChannelJustAudio extends JustAudioPlatform {
   static const _mainChannel = MethodChannel('com.ryanheise.just_audio.methods');
+
+  @override
+  bool get supportsMappingAudioSource => Platform.isAndroid;
 
   @override
   Future<AudioPlayerPlatform> init(InitRequest request) async {

--- a/just_audio_platform_interface/lib/method_channel_just_audio.dart
+++ b/just_audio_platform_interface/lib/method_channel_just_audio.dart
@@ -240,7 +240,7 @@ class MethodChannelAudioPlayer extends AudioPlayerPlatform {
         final id = (call.arguments as Map)['id'] as String;
         final message = getAudioSourceMessage(id) as MappingAudioSourceMessage;
         final innerMessage = await message.createAudioSourceMessage();
-        return innerMessage.toMap();
+        return innerMessage?.toMap();
       default:
         throw UnimplementedError('Unimplemented method: ${call.method}');
     }

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -23,7 +23,10 @@ class JustAudioPlugin extends JustAudioPlatform {
           code: "error",
           message: "Platform player ${request.id} already exists");
     }
-    final player = Html5AudioPlayer(id: request.id);
+    final player = Html5AudioPlayer(
+      id: request.id,
+      getAudioServiceMessage: request.getAudioSourceMessage,
+    );
     players[request.id] = player;
     return player;
   }
@@ -57,7 +60,13 @@ abstract class JustAudioPlayer extends AudioPlayerPlatform {
   double _speed = 1.0;
 
   /// Creates a platform player with the given [id].
-  JustAudioPlayer({required String id}) : super(id);
+  JustAudioPlayer({
+    required String id,
+    required AudioSourceMessageGetter getAudioServiceMessage,
+  }) : super(
+          id,
+          getAudioSourceMessage: getAudioServiceMessage,
+        );
 
   @mustCallSuper
   Future<void> release() async {
@@ -108,7 +117,13 @@ class Html5AudioPlayer extends JustAudioPlayer {
   final Map<String, AudioSourcePlayer> _audioSourcePlayers = {};
 
   /// Creates an [Html5AudioPlayer] with the given [id].
-  Html5AudioPlayer({required String id}) : super(id: id) {
+  Html5AudioPlayer(
+      {required String id,
+      required AudioSourceMessageGetter getAudioServiceMessage})
+      : super(
+          id: id,
+          getAudioServiceMessage: getAudioServiceMessage,
+        ) {
     _audioElement.addEventListener('durationchange', (event) {
       _durationCompleter?.complete();
       broadcastPlaybackEvent();

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -724,6 +724,7 @@ class HlsAudioSourcePlayer extends UriAudioSourcePlayer {
       : super(html5AudioPlayer, id, uri, headers);
 }
 
+/// A player for a [MappingAudioSourceMessage].
 class MappingAudioSourcePlayer extends IndexedAudioSourcePlayer {
   final Future<IndexedAudioSourcePlayer?> Function() _generateInnerPlayer;
   IndexedAudioSourcePlayer? _innerPlayer;

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -17,6 +17,9 @@ class JustAudioPlugin extends JustAudioPlatform {
   }
 
   @override
+  bool get supportsMappingAudioSource => true;
+
+  @override
   Future<AudioPlayerPlatform> init(InitRequest request) async {
     if (players.containsKey(request.id)) {
       throw PlatformException(


### PR DESCRIPTION
This PR implements some of the ideas discussed in #777.

## API additions

`MappingAudioSource`, a new type of `AudioSource`, has been added. On supported platforms (more on that later), it allows the creation of an `AudioSource` to be deferred until it is truly needed by the player (for preloading or playback purposes).

This is useful for APIs that require a secondary request to retrieve an audio URL. For example:

```dart
final apiService = ApiService();

final queue = await apiService.getQueue();
final mappingAudioSources = [
  for (final queueItem in queue)
      MappingAudioSource(queueItem, (queueItem) async => AudioService.uri(await apiService.getUrl(queueItem)));
];
```

Any type of `IndexedAudioSource` can be lazily created in this fashion.

If there's a problem creating the `AudioSource`, `null` can be returned. This causes an empty placeholder to be used, causing the player to move on to the next item (or stop).

The availability of `MappingAudioSource` on the current platform can be checked with the static `MappingAudioSource.supportedOnCurrentPlatform` getter.

## Platform interface changes

The platform interface has been changed in a non-breaking manner.

- `MappingAudioSourceMessage` has been added
- The main platform interface now takes a `getAudioSourceMessage` function as a constructor argument. This function should return an `AudioSource` associated with an ID. It is an optional named argument, and will use a placeholder that throws when it is called if the real implementation is not provided.
- The main platform interface has gained a `supportsMappingAudioSource` getter that is false by default.

## Implementation details

### Deferred `AudioSource` creation
This feature has been implemented by adding new audio source players (`AudioSourcePlayer` on the Web, `MediaSource` on Android) that create, and start using, an underlying audio source player when their prepare/load method is first called.

The MethodChannel platform interface implementation has implemented a "createMappedAudioSourceSource" API to facilitate this. When given a `MappingAudioSource` ID, it creates the underlying `AudioSource` and returns its message representation.

### Placeholder media when `null` is returned

If a problem is encountered creating the `AudioSource` in the `MappingAudioSource`, `null` should be returned. When this happens, an empty audio source is used. This is implemented with:

- A zero-length `SilenceMediaSource` on Android
- A zero-length WAV data URI on the Web ([supported in every modern browser for a long time](https://caniuse.com/wav))

## Supported platforms

As the typical implementation of this feature relies on asynchronous `load`/`prepare` methods in platform audio player APIs, supporting it is not feasible on platforms like macOS and iOS.

I have [experimented](https://github.com/hacker1024/just_audio/tree/feature/proxy_url_audio_source) with taking advantage of the proxy functionality to allow deferred URLs to be used in a similar way, but this isn't very useful at the moment as macOS (and I assume iOS) make a HTTP request as soon as the source is added, even if it's not meant to be played yet.