### PR TITLE
Update pub.dev links

### DIFF
--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,7 +1,8 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and concatenate any sound from any source (asset/file/URL/stream) in a variety of audio formats with gapless playback.
 version: 0.9.29
-homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio
+repository: https://github.com/ryanheise/just_audio/tree/master/just_audio
+issue_tracker: https://github.com/ryanheise/just_audio/issues
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).