### PR TITLE
 Fixed: seek to index of queue item issue on iOS, android is fine

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1108,6 +1108,7 @@ class AudioPlayer {
           _playbackEvent = prevPlaybackEvent.copyWith(
             updatePosition: position,
             updateTime: DateTime.now(),
+            currentIndex: index,
           );
           _playbackEventSubject.add(_playbackEvent);
           _positionDiscontinuitySubject.add(PositionDiscontinuity(


### PR DESCRIPTION
Fixed: seek function, the issue is when many items are loaded in the playlist and we move to seek to index of queue item it glitches, and sometimes index remains unchanged in playbackEventStream only in iOS. but working fine on android devices.