### PR TITLE
Feature: Add `package` param to `AudioPlayer.setAsset()`

### DIFF
--- a/just_audio/CHANGELOG.md
+++ b/just_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.31
+
+* Add AudioPlayer.setAsset() a package argument (@ewertonls)
+
 ## 0.9.30
 
 * Upgrade ExoPlayer to 2.18.1.

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -692,15 +692,25 @@ class AudioPlayer {
   /// setAudioSource(AudioSource.uri(Uri.parse('asset:///$assetPath')),
   ///     initialPosition: Duration.zero, preload: true);
   /// ```
+  /// The [package] argument must be non-null if an asset from package is being
+  /// fetched.
   ///
   /// See [setAudioSource] for a detailed explanation of the options.
   Future<Duration?> setAsset(
     String assetPath, {
+    String? package,
     bool preload = true,
     Duration? initialPosition,
-  }) =>
-      setAudioSource(AudioSource.uri(Uri.parse('asset:///$assetPath')),
-          initialPosition: initialPosition, preload: preload);
+  }) {
+    final keyName =
+        package == null ? assetPath : 'packages/$package/$assetPath';
+
+    return setAudioSource(
+      AudioSource.uri(Uri.parse('asset:///$keyName')),
+      initialPosition: initialPosition,
+      preload: preload,
+    );
+  }
 
   /// Sets the source from which this audio player should fetch audio.
   ///

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and concatenate any sound from any source (asset/file/URL/stream) in a variety of audio formats with gapless playback.
-version: 0.9.30
+version: 0.9.31
 repository: https://github.com/ryanheise/just_audio/tree/minor/just_audio
 issue_tracker: https://github.com/ryanheise/just_audio/issues
 


### PR DESCRIPTION
Add package argument to `setAsset` so assets in packages can be loaded.
closes #863