### PR TITLE
Fix 'proxy0.9' test transform error

### DIFF
--- a/just_audio/test/just_audio_test.dart
+++ b/just_audio/test/just_audio_test.dart
@@ -422,10 +422,7 @@ void runTests() {
     //final socket = await Socket.connect(uri.host, uri.port);
     socket.write('GET ${uri.path} HTTP/1.0\n\n');
     await socket.flush();
-    final responseText = await socket
-        .transform(Converter.castFrom<List<int>, String, Uint8List, String>(
-            utf8.decoder))
-        .join();
+    final responseText = await utf8.decoder.bind(socket).join();
     await socket.close();
     expect(responseText, equals('Hello'));
     await server.stop();


### PR DESCRIPTION
Fix `'Converter<dynamic, String>' can't be assigned to the parameter type 'StreamTransformer<Uint8List, dynamic>'` by using `StreamTransformer.bind()` instead of `Stream.transform()` on
https://github.com/ryanheise/just_audio/blob/48f2d275d470e8e2296b502b2e21c463497efbd4/just_audio/test/just_audio_test.dart#L425-L428

The above method is dropped since dart-sdk 2.5 (see [dart-sdk 2.5.0 breaking change 36900](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#core-libraries-12)) and can be fixed either by using

```dart
final responseText = await utf8.decoder.bind(socket).join();
```

or

```dart
final responseText = await socket.transform<String>(StreamTransformer.castFrom(utf8.decoder)).join();
```