### PR TITLE
Fix exception on calling LockCachingAudioSource clearCache after the player is stopped

### DIFF
--- a/just_audio/CHANGELOG.md
+++ b/just_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.35
+
+* Fix exception on calling LockCachingAudioSource clearCache after the player is stopped (@Akalanka47000).
+
 ## 0.9.34
 
 * Support AGP 8 (@josephcrowell).

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1254,6 +1254,10 @@ class AudioPlayer {
     final currentIndex = this.currentIndex;
     final audioSource = _audioSource;
 
+    if (!active && audioSource is LockCachingAudioSource && audioSource._downloading) {
+      audioSource._downloading = false;
+    }
+
     void subscribeToEvents(AudioPlayerPlatform platform) {
       _playerDataSubscription =
           platform.playerDataMessageStream.listen((message) {

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and concatenate any sound from any source (asset/file/URL/stream) in a variety of audio formats with gapless playback.
-version: 0.9.34
+version: 0.9.35
 repository: https://github.com/ryanheise/just_audio/tree/minor/just_audio
 issue_tracker: https://github.com/ryanheise/just_audio/issues
 topics:


### PR DESCRIPTION
Steps to reproduce:-

```dart

final player = AudioPlayer();

final audioSource = LockCachingAudioSource(Uri.parse("stream_link"));

await player.setAudioSource(audioSource);

await player.play()

// After some time

await player.stop()
await audioSource.clearCache()

// or 

player.processingStateStream.listen((processingState) {
   if processingState == ProcessingState.idle) {
       await audioSource.clearCache();
   }
});

```

Exception being mitigated:-

```bash
I/ExoPlayerImpl(11100): Release 28530fd [ExoPlayerLib/2.18.7] [joyeuse, Redmi Note 9 Pro, Xiaomi, 29] [goog.exo.core, goog.exo.exoplayer, goog.exo.decoder, goog.exo.datasource, goog.exo.extractor]
E/flutter (11100): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Exception: Cannot clear cache while download is in progress
E/flutter (11100): #0      LockCachingAudioSource.clearCache (package:just_audio/just_audio.dart:2769:7)
E/flutter (11100): #1      PlayerBloc.initialize.<anonymous closure> (package:abc/state/ui/player/player_bloc.dart:55:57)
E/flutter (11100): #2      _RootZone.runUnaryGuarded (dart:async/zone.dart:1594:10)
E/flutter (11100): #3      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
E/flutter (11100): #4      _BufferingStreamSubscription._add (dart:async/stream_impl.dart:271:7)
E/flutter (11100): #5      _MultiStreamController.addSync (dart:async/stream_impl.dart:1044:36)
E/flutter (11100): #6      _MultiControllerSink.add (package:rxdart/src/utils/forwarding_stream.dart:130:35)
E/flutter (11100): #7      _StartWithStreamSink.onData (package:rxdart/src/transformers/start_with.dart:12:31)
E/flutter (11100): #8      _RootZone.runUnaryGuarded (dart:async/zone.dart:1594:10)
E/flutter (11100): #9      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
E/flutter (11100): #10     _DelayedData.perform (dart:async/stream_impl.dart:515:14)
E/flutter (11100): #11     _PendingEvents.handleNext (dart:async/stream_impl.dart:620:11)
E/flutter (11100): #12     _PendingEvents.schedule.<anonymous closure> (dart:async/stream_impl.dart:591:7)
E/flutter (11100): #13     _microtaskLoop (dart:async/schedule_microtask.dart:40:21)
E/flutter (11100): #14     _startMicrotaskLoop (dart:async/schedule_microtask.dart:49:5)
E/flutter (11100): 
```