### PR TITLE
Stop passing a nullable value to Completer<nn-type>.completer.

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -3771,9 +3771,9 @@ class AndroidEqualizer extends AudioEffect with AndroidAudioEffect {
     }
     final response = await platform
         .androidEqualizerGetParameters(AndroidEqualizerGetParametersRequest());
-    final parameters =
+    final receivedParameters =
         AndroidEqualizerParameters._fromMessage(_player!, response.parameters);
-    _parametersCompleter.complete(parameters);
+    _parametersCompleter.complete(receivedParameters);
   }
 
   /// The parameter values of this equalizer.

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -3756,7 +3756,6 @@ class AndroidEqualizerParameters {
 /// An [AudioEffect] for Android that can adjust the gain for different
 /// frequency bands of an [AudioPlayer]'s audio signal.
 class AndroidEqualizer extends AudioEffect with AndroidAudioEffect {
-  AndroidEqualizerParameters? _parameters;
   final Completer<AndroidEqualizerParameters> _parametersCompleter =
       Completer<AndroidEqualizerParameters>();
 
@@ -3772,9 +3771,9 @@ class AndroidEqualizer extends AudioEffect with AndroidAudioEffect {
     }
     final response = await platform
         .androidEqualizerGetParameters(AndroidEqualizerGetParametersRequest());
-    _parameters =
+    final parameters =
         AndroidEqualizerParameters._fromMessage(_player!, response.parameters);
-    _parametersCompleter.complete(_parameters);
+    _parametersCompleter.complete(parameters);
   }
 
   /// The parameter values of this equalizer.


### PR DESCRIPTION
This is cleanup work required to start enforcing this with static analysis, as per https://github.com/dart-lang/sdk/issues/53253.

Real quick this issue is that this code is unsafe:

```dart
void f(Completer<int> c, int? i) {
  Future<int>.value(i); // Ouch!
  c.complete(i);        // Ouch!
}
```
