### PR TITLE
Upgrade UUID dependency from ^3.0.1 to ^4.0.0

### DIFF
--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   path: ^1.8.0
   path_provider: ^2.0.0
   async: ^2.5.0
-  uuid: ^3.0.1
+  uuid: ^4.0.0
   crypto: ^3.0.0
   meta: ^1.3.0
   flutter:


### PR DESCRIPTION
This is a small PR that upgrades the minimum UUID dependency from ^3.0.1 to ^4.0.0 which supports the [new UUID formats](https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-01.html#name-uuidv7-layout-and-bit-order). I'm not really sure if this constitutes as a breaking change. Please do let me know if this should be branched off the `major` branch instead.