### PR TITLE
Change UUID constraint to `>=3.0.1 <5.0.0`

### DIFF
--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   path: ^1.8.0
   path_provider: ^2.0.0
   async: ^2.5.0
-  uuid: ^3.0.1
+  uuid: ^4.0.0
   crypto: ^3.0.0
   meta: ^1.3.0
   flutter:

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   path: ^1.8.0
   path_provider: ^2.0.0
   async: ^2.5.0
-  uuid: ^4.0.0
+  uuid: '>=3.0.1 <5.0.0'
   crypto: ^3.0.0
   meta: ^1.3.0
   flutter:


### PR DESCRIPTION
Resolves https://github.com/ryanheise/just_audio/issues/966.

Related to https://github.com/ryanheise/just_audio/pull/1054.

is is a small PR that changes the UUID dependency from `^3.0.1` to `>=3.0.1 <5.0.0` which supports the [new UUID formats](https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-01.html#name-uuidv7-layout-and-bit-order).