### PR TITLE
Fix PathNotFoundException when using LockCachingAudioSource

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -123,7 +123,8 @@ class AudioPlayer {
   final _loopModeSubject = BehaviorSubject.seeded(LoopMode.off);
   final _shuffleModeEnabledSubject = BehaviorSubject.seeded(false);
   final _androidAudioSessionIdSubject = BehaviorSubject<int?>();
-  final _positionDiscontinuitySubject = PublishSubject<PositionDiscontinuity>(sync: true);
+  final _positionDiscontinuitySubject =
+      PublishSubject<PositionDiscontinuity>(sync: true);
   var _seeking = false;
   // ignore: close_sinks
   BehaviorSubject<Duration>? _positionSubject;
@@ -173,15 +174,16 @@ class AudioPlayer {
     bool androidOffloadSchedulingEnabled = false,
   })  : _id = _uuid.v4(),
         _userAgent = userAgent,
-        _androidApplyAudioAttributes = androidApplyAudioAttributes && _isAndroid(),
+        _androidApplyAudioAttributes =
+            androidApplyAudioAttributes && _isAndroid(),
         _handleAudioSessionActivation = handleAudioSessionActivation,
         _audioLoadConfiguration = audioLoadConfiguration,
         _audioPipeline = audioPipeline ?? AudioPipeline(),
         _androidOffloadSchedulingEnabled = androidOffloadSchedulingEnabled {
     _audioPipeline._setup(this);
     if (_audioLoadConfiguration?.darwinLoadControl != null) {
-      _automaticallyWaitsToMinimizeStalling =
-          _audioLoadConfiguration!.darwinLoadControl!.automaticallyWaitsToMinimizeStalling;
+      _automaticallyWaitsToMinimizeStalling = _audioLoadConfiguration!
+          .darwinLoadControl!.automaticallyWaitsToMinimizeStalling;
     }
     _playbackEventSubject.add(_playbackEvent);
     _processingStateSubject.addStream(playbackEventStream
@@ -204,7 +206,8 @@ class AudioPlayer {
       if (prev.currentIndex == null || curr.currentIndex == null) return;
       if (curr.currentIndex != prev.currentIndex) {
         // If we've changed item without seeking, it must be an autoAdvance.
-        _positionDiscontinuitySubject.add(PositionDiscontinuity(PositionDiscontinuityReason.autoAdvance, prev, curr));
+        _positionDiscontinuitySubject.add(PositionDiscontinuity(
+            PositionDiscontinuityReason.autoAdvance, prev, curr));
       } else {
         // If the item is the same, try to determine whether we have looped
         // back.
@@ -215,10 +218,12 @@ class AudioPlayer {
         if (currPos >= const Duration(milliseconds: 300)) return;
         final duration = this.duration;
         if (duration != null && prevPos < duration * 0.6) return;
-        if (duration == null && currPos - prevPos < const Duration(seconds: 1)) {
+        if (duration == null &&
+            currPos - prevPos < const Duration(seconds: 1)) {
           return;
         }
-        _positionDiscontinuitySubject.add(PositionDiscontinuity(PositionDiscontinuityReason.autoAdvance, prev, curr));
+        _positionDiscontinuitySubject.add(PositionDiscontinuity(
+            PositionDiscontinuityReason.autoAdvance, prev, curr));
       }
     }, onError: (Object e, StackTrace st) {});
     _currentIndexSubject.addStream(playbackEventStream
@@ -229,8 +234,8 @@ class AudioPlayer {
         .map((event) => event.androidAudioSessionId)
         .distinct()
         .handleError((Object err, StackTrace stackTrace) {/* noop */}));
-    _sequenceStateSubject
-        .addStream(Rx.combineLatest5<List<IndexedAudioSource>?, List<int>?, int?, bool, LoopMode, SequenceState?>(
+    _sequenceStateSubject.addStream(Rx.combineLatest5<List<IndexedAudioSource>?,
+        List<int>?, int?, bool, LoopMode, SequenceState?>(
       sequenceStream,
       shuffleIndicesStream,
       currentIndexStream,
@@ -250,13 +255,17 @@ class AudioPlayer {
         );
       },
     ).distinct().handleError((Object err, StackTrace stackTrace) {/* noop */}));
-    _playerStateSubject.addStream(Rx.combineLatest2<bool, PlaybackEvent, PlayerState>(
-            playingStream, playbackEventStream, (playing, event) => PlayerState(playing, event.processingState))
-        .distinct()
-        .handleError((Object err, StackTrace stackTrace) {/* noop */}));
+    _playerStateSubject.addStream(
+        Rx.combineLatest2<bool, PlaybackEvent, PlayerState>(
+                playingStream,
+                playbackEventStream,
+                (playing, event) => PlayerState(playing, event.processingState))
+            .distinct()
+            .handleError((Object err, StackTrace stackTrace) {/* noop */}));
     _shuffleModeEnabledSubject.add(false);
     _loopModeSubject.add(LoopMode.off);
-    _setPlatformActive(false, force: true)?.catchError((dynamic e) async => null);
+    _setPlatformActive(false, force: true)
+        ?.catchError((dynamic e) async => null);
     _sequenceSubject.add(null);
     // Respond to changes to AndroidAudioAttributes configuration.
     if (androidApplyAudioAttributes && _isAndroid()) {
@@ -279,7 +288,8 @@ class AudioPlayer {
             switch (event.type) {
               case AudioInterruptionType.duck:
                 assert(_isAndroid());
-                if (session.androidAudioAttributes!.usage == AndroidAudioUsage.game) {
+                if (session.androidAudioAttributes!.usage ==
+                    AndroidAudioUsage.game) {
                   setVolume(volume / 2);
                 }
                 _playInterrupted = false;
@@ -324,7 +334,8 @@ class AudioPlayer {
   Future<void> _removeOldAssetCacheDir() async {
     if (kIsWeb) return;
     try {
-      final oldAssetCacheDir = Directory(p.join((await getTemporaryDirectory()).path, 'just_audio_asset_cache'));
+      final oldAssetCacheDir = Directory(p.join(
+          (await getTemporaryDirectory()).path, 'just_audio_asset_cache'));
       if (oldAssetCacheDir.existsSync()) {
         try {
           oldAssetCacheDir.deleteSync(recursive: true);
@@ -360,7 +371,8 @@ class AudioPlayer {
   ProcessingState get processingState => _playbackEvent.processingState;
 
   /// A stream of [ProcessingState]s.
-  Stream<ProcessingState> get processingStateStream => _processingStateSubject.stream;
+  Stream<ProcessingState> get processingStateStream =>
+      _processingStateSubject.stream;
 
   /// Whether the player is playing.
   bool get playing => _playingSubject.nvalue!;
@@ -390,13 +402,16 @@ class AudioPlayer {
   bool get skipSilenceEnabled => _skipSilenceEnabledSubject.nvalue!;
 
   /// A stream of current skipSilenceEnabled factor values.
-  Stream<bool> get skipSilenceEnabledStream => _skipSilenceEnabledSubject.stream;
+  Stream<bool> get skipSilenceEnabledStream =>
+      _skipSilenceEnabledSubject.stream;
 
   /// The position up to which buffered audio is available.
-  Duration get bufferedPosition => _bufferedPositionSubject.nvalue ?? Duration.zero;
+  Duration get bufferedPosition =>
+      _bufferedPositionSubject.nvalue ?? Duration.zero;
 
   /// A stream of buffered positions.
-  Stream<Duration> get bufferedPositionStream => _bufferedPositionSubject.stream;
+  Stream<Duration> get bufferedPositionStream =>
+      _bufferedPositionSubject.stream;
 
   /// The latest ICY metadata received through the audio source, or `null` if no
   /// metadata is available.
@@ -407,7 +422,8 @@ class AudioPlayer {
 
   /// The current player state containing only the processing and playing
   /// states.
-  PlayerState get playerState => _playerStateSubject.nvalue ?? PlayerState(false, ProcessingState.idle);
+  PlayerState get playerState =>
+      _playerStateSubject.nvalue ?? PlayerState(false, ProcessingState.idle);
 
   /// A stream of [PlayerState]s.
   Stream<PlayerState> get playerStateStream => _playerStateSubject.stream;
@@ -417,7 +433,8 @@ class AudioPlayer {
   List<IndexedAudioSource>? get sequence => _sequenceSubject.nvalue;
 
   /// A stream broadcasting the current sequence of indexed audio sources.
-  Stream<List<IndexedAudioSource>?> get sequenceStream => _sequenceSubject.stream;
+  Stream<List<IndexedAudioSource>?> get sequenceStream =>
+      _sequenceSubject.stream;
 
   /// The current shuffled sequence of indexed audio sources, or `null` if no
   /// audio source is set.
@@ -442,7 +459,8 @@ class AudioPlayer {
   SequenceState? get sequenceState => _sequenceStateSubject.nvalue;
 
   /// A stream broadcasting the current [SequenceState].
-  Stream<SequenceState?> get sequenceStateStream => _sequenceStateSubject.stream;
+  Stream<SequenceState?> get sequenceStateStream =>
+      _sequenceStateSubject.stream;
 
   /// Whether there is another item after the current index.
   bool get hasNext => nextIndex != null;
@@ -455,12 +473,16 @@ class AudioPlayer {
   /// returns `null`.
   List<int>? get effectiveIndices {
     if (shuffleIndices == null || sequence == null) return null;
-    return shuffleModeEnabled ? shuffleIndices : List.generate(sequence!.length, (i) => i);
+    return shuffleModeEnabled
+        ? shuffleIndices
+        : List.generate(sequence!.length, (i) => i);
   }
 
   List<int>? get _effectiveIndicesInv {
     if (shuffleIndices == null || sequence == null) return null;
-    return shuffleModeEnabled ? _shuffleIndicesInv : List.generate(sequence!.length, (i) => i);
+    return shuffleModeEnabled
+        ? _shuffleIndicesInv
+        : List.generate(sequence!.length, (i) => i);
   }
 
   /// The index of the next item to be played, or `null` if there is no next
@@ -501,24 +523,29 @@ class AudioPlayer {
   bool get shuffleModeEnabled => _shuffleModeEnabledSubject.nvalue!;
 
   /// A stream of the shuffle mode status.
-  Stream<bool> get shuffleModeEnabledStream => _shuffleModeEnabledSubject.stream;
+  Stream<bool> get shuffleModeEnabledStream =>
+      _shuffleModeEnabledSubject.stream;
 
   /// The current Android AudioSession ID or `null` if not set.
   int? get androidAudioSessionId => _playbackEvent.androidAudioSessionId;
 
   /// Broadcasts the current Android AudioSession ID or `null` if not set.
-  Stream<int?> get androidAudioSessionIdStream => _androidAudioSessionIdSubject.stream;
+  Stream<int?> get androidAudioSessionIdStream =>
+      _androidAudioSessionIdSubject.stream;
 
   /// A stream broadcasting every position discontinuity.
-  Stream<PositionDiscontinuity> get positionDiscontinuityStream => _positionDiscontinuitySubject.stream;
+  Stream<PositionDiscontinuity> get positionDiscontinuityStream =>
+      _positionDiscontinuitySubject.stream;
 
   /// Whether the player should automatically delay playback in order to
   /// minimize stalling. (iOS 10.0 or later only)
-  bool get automaticallyWaitsToMinimizeStalling => _automaticallyWaitsToMinimizeStalling;
+  bool get automaticallyWaitsToMinimizeStalling =>
+      _automaticallyWaitsToMinimizeStalling;
 
   /// Whether the player can use the network for live streaming while paused on
   /// iOS/macOS.
-  bool get canUseNetworkResourcesForLiveStreamingWhilePaused => _canUseNetworkResourcesForLiveStreamingWhilePaused;
+  bool get canUseNetworkResourcesForLiveStreamingWhilePaused =>
+      _canUseNetworkResourcesForLiveStreamingWhilePaused;
 
   /// The preferred peak bit rate (in bits per second) of bandwidth usage on iOS/macOS.
   double get preferredPeakBitRate => _preferredPeakBitRate;
@@ -528,8 +555,11 @@ class AudioPlayer {
 
   Duration _getPositionFor(PlaybackEvent playbackEvent) {
     if (playing && processingState == ProcessingState.ready) {
-      final result = playbackEvent.updatePosition + (DateTime.now().difference(playbackEvent.updateTime)) * speed;
-      return playbackEvent.duration == null || result <= playbackEvent.duration! ? result : playbackEvent.duration!;
+      final result = playbackEvent.updatePosition +
+          (DateTime.now().difference(playbackEvent.updateTime)) * speed;
+      return playbackEvent.duration == null || result <= playbackEvent.duration!
+          ? result
+          : playbackEvent.duration!;
     } else {
       return playbackEvent.updatePosition;
     }
@@ -548,7 +578,9 @@ class AudioPlayer {
       _positionSubject = BehaviorSubject<Duration>();
       if (!_disposed) {
         _positionSubject!.addStream(createPositionStream(
-            steps: 800, minPeriod: const Duration(milliseconds: 16), maxPeriod: const Duration(milliseconds: 200)));
+            steps: 800,
+            minPeriod: const Duration(milliseconds: 16),
+            maxPeriod: const Duration(milliseconds: 200)));
       }
     }
     return _positionSubject!.stream;
@@ -653,7 +685,8 @@ class AudioPlayer {
     Duration? initialPosition,
     bool preload = true,
   }) =>
-      setAudioSource(AudioSource.file(filePath), initialPosition: initialPosition, preload: preload);
+      setAudioSource(AudioSource.file(filePath),
+          initialPosition: initialPosition, preload: preload);
 
   /// Convenience method to set the audio source to an asset, preloaded by
   /// default, with an initial position of zero by default.
@@ -710,9 +743,11 @@ class AudioPlayer {
   }) async {
     if (_disposed) return null;
     _audioSource = null;
-    _initialSeekValues = _InitialSeekValues(position: initialPosition, index: initialIndex);
-    _playbackEventSubject.add(_playbackEvent =
-        PlaybackEvent(currentIndex: initialIndex ?? 0, updatePosition: initialPosition ?? Duration.zero));
+    _initialSeekValues =
+        _InitialSeekValues(position: initialPosition, index: initialIndex);
+    _playbackEventSubject.add(_playbackEvent = PlaybackEvent(
+        currentIndex: initialIndex ?? 0,
+        updatePosition: initialPosition ?? Duration.zero));
     _audioSource = source;
     _broadcastSequence();
     Duration? duration;
@@ -743,7 +778,8 @@ class AudioPlayer {
     if (_active) {
       final initialSeekValues = _initialSeekValues;
       _initialSeekValues = null;
-      return await _load(await _platform, _audioSource!, initialSeekValues: initialSeekValues);
+      return await _load(await _platform, _audioSource!,
+          initialSeekValues: initialSeekValues);
     } else {
       // This will implicitly load the current audio source.
       return await _setPlatformActive(true);
@@ -761,9 +797,11 @@ class AudioPlayer {
     _shuffleIndicesSubject.add(_audioSource?.shuffleIndices);
     final shuffleIndicesLength = shuffleIndices?.length ?? 0;
     if (_shuffleIndicesInv.length > shuffleIndicesLength) {
-      _shuffleIndicesInv.removeRange(shuffleIndicesLength, _shuffleIndicesInv.length);
+      _shuffleIndicesInv.removeRange(
+          shuffleIndicesLength, _shuffleIndicesInv.length);
     } else if (_shuffleIndicesInv.length < shuffleIndicesLength) {
-      _shuffleIndicesInv.addAll(List.filled(shuffleIndicesLength - _shuffleIndicesInv.length, 0));
+      _shuffleIndicesInv.addAll(
+          List.filled(shuffleIndicesLength - _shuffleIndicesInv.length, 0));
     }
     for (var i = 0; i < shuffleIndicesLength; i++) {
       _shuffleIndicesInv[shuffleIndices![i]] = i;
@@ -804,7 +842,8 @@ class AudioPlayer {
         throw PlatformException(code: 'abort', message: 'Loading interrupted');
       }
       // Wait for loading state to pass.
-      await processingStateStream.firstWhere((state) => state != ProcessingState.loading);
+      await processingStateStream
+          .firstWhere((state) => state != ProcessingState.loading);
       checkInterruption();
       return duration;
     } on PlatformException catch (e) {
@@ -887,7 +926,8 @@ class AudioPlayer {
         } else {
           // If the native platform wasn't already active, activating it will
           // implicitly restore the playing state and send a play request.
-          _setPlatformActive(true, playCompleter: playCompleter)?.catchError((dynamic e) async => null);
+          _setPlatformActive(true, playCompleter: playCompleter)
+              ?.catchError((dynamic e) async => null);
         }
       }
     } else {
@@ -916,7 +956,8 @@ class AudioPlayer {
     await (await _platform).pause(PauseRequest());
   }
 
-  Future<void> _sendPlayRequest(AudioPlayerPlatform platform, Completer<void>? playCompleter) async {
+  Future<void> _sendPlayRequest(
+      AudioPlayerPlatform platform, Completer<void>? playCompleter) async {
     try {
       if (!playing) return; // defensive
       await platform.play(PlayRequest());
@@ -936,7 +977,8 @@ class AudioPlayer {
   /// decoders alive so that the app can quickly resume audio playback.
   Future<void> stop() async {
     if (_disposed) return;
-    final future = _setPlatformActive(false)?.catchError((dynamic e) async => null);
+    final future =
+        _setPlatformActive(false)?.catchError((dynamic e) async => null);
 
     _playInterrupted = false;
     // Update local state immediately so that queries aren't surprised.
@@ -959,7 +1001,8 @@ class AudioPlayer {
     if (enabled == previouslyEnabled) return;
     _skipSilenceEnabledSubject.add(enabled);
     try {
-      await (await _platform).setSkipSilence(SetSkipSilenceRequest(enabled: enabled));
+      await (await _platform)
+          .setSkipSilence(SetSkipSilenceRequest(enabled: enabled));
     } catch (e) {
       _skipSilenceEnabledSubject.add(previouslyEnabled);
       rethrow;
@@ -998,15 +1041,17 @@ class AudioPlayer {
   Future<void> setLoopMode(LoopMode mode) async {
     if (_disposed) return;
     _loopModeSubject.add(mode);
-    await (await _platform).setLoopMode(SetLoopModeRequest(loopMode: LoopModeMessage.values[mode.index]));
+    await (await _platform).setLoopMode(
+        SetLoopModeRequest(loopMode: LoopModeMessage.values[mode.index]));
   }
 
   /// Sets whether shuffle mode is enabled.
   Future<void> setShuffleModeEnabled(bool enabled) async {
     if (_disposed) return;
     _shuffleModeEnabledSubject.add(enabled);
-    await (await _platform)
-        .setShuffleMode(SetShuffleModeRequest(shuffleMode: enabled ? ShuffleModeMessage.all : ShuffleModeMessage.none));
+    await (await _platform).setShuffleMode(SetShuffleModeRequest(
+        shuffleMode:
+            enabled ? ShuffleModeMessage.all : ShuffleModeMessage.none));
   }
 
   /// Recursively shuffles the children of the currently loaded [AudioSource].
@@ -1017,16 +1062,20 @@ class AudioPlayer {
     if (_audioSource == null) return;
     _audioSource!._shuffle(initialIndex: currentIndex);
     _updateShuffleIndices();
-    await (await _platform).setShuffleOrder(SetShuffleOrderRequest(audioSourceMessage: _audioSource!._toMessage()));
+    await (await _platform).setShuffleOrder(
+        SetShuffleOrderRequest(audioSourceMessage: _audioSource!._toMessage()));
   }
 
   /// Sets automaticallyWaitsToMinimizeStalling for AVPlayer in iOS 10.0 or later, defaults to true.
   /// Has no effect on Android clients
-  Future<void> setAutomaticallyWaitsToMinimizeStalling(final bool automaticallyWaitsToMinimizeStalling) async {
+  Future<void> setAutomaticallyWaitsToMinimizeStalling(
+      final bool automaticallyWaitsToMinimizeStalling) async {
     if (_disposed) return;
-    _automaticallyWaitsToMinimizeStalling = automaticallyWaitsToMinimizeStalling;
+    _automaticallyWaitsToMinimizeStalling =
+        automaticallyWaitsToMinimizeStalling;
     await (await _platform).setAutomaticallyWaitsToMinimizeStalling(
-        SetAutomaticallyWaitsToMinimizeStallingRequest(enabled: automaticallyWaitsToMinimizeStalling));
+        SetAutomaticallyWaitsToMinimizeStallingRequest(
+            enabled: automaticallyWaitsToMinimizeStalling));
   }
 
   /// Sets canUseNetworkResourcesForLiveStreamingWhilePaused on iOS/macOS,
@@ -1034,17 +1083,21 @@ class AudioPlayer {
   Future<void> setCanUseNetworkResourcesForLiveStreamingWhilePaused(
       final bool canUseNetworkResourcesForLiveStreamingWhilePaused) async {
     if (_disposed) return;
-    _canUseNetworkResourcesForLiveStreamingWhilePaused = canUseNetworkResourcesForLiveStreamingWhilePaused;
-    await (await _platform).setCanUseNetworkResourcesForLiveStreamingWhilePaused(
-        SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest(
-            enabled: canUseNetworkResourcesForLiveStreamingWhilePaused));
+    _canUseNetworkResourcesForLiveStreamingWhilePaused =
+        canUseNetworkResourcesForLiveStreamingWhilePaused;
+    await (await _platform)
+        .setCanUseNetworkResourcesForLiveStreamingWhilePaused(
+            SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest(
+                enabled: canUseNetworkResourcesForLiveStreamingWhilePaused));
   }
 
   /// Sets preferredPeakBitRate on iOS/macOS, defaults to true.
-  Future<void> setPreferredPeakBitRate(final double preferredPeakBitRate) async {
+  Future<void> setPreferredPeakBitRate(
+      final double preferredPeakBitRate) async {
     if (_disposed) return;
     _preferredPeakBitRate = preferredPeakBitRate;
-    await (await _platform).setPreferredPeakBitRate(SetPreferredPeakBitRateRequest(bitRate: preferredPeakBitRate));
+    await (await _platform).setPreferredPeakBitRate(
+        SetPreferredPeakBitRateRequest(bitRate: preferredPeakBitRate));
   }
 
   /// Seeks to a particular [position]. If a composition of multiple
@@ -1068,9 +1121,12 @@ class AudioPlayer {
             updateTime: DateTime.now(),
           );
           _playbackEventSubject.add(_playbackEvent);
-          _positionDiscontinuitySubject
-              .add(PositionDiscontinuity(PositionDiscontinuityReason.seek, prevPlaybackEvent, _playbackEvent));
-          await (await _platform).seek(SeekRequest(position: position, index: index));
+          _positionDiscontinuitySubject.add(PositionDiscontinuity(
+              PositionDiscontinuityReason.seek,
+              prevPlaybackEvent,
+              _playbackEvent));
+          await (await _platform)
+              .seek(SeekRequest(position: position, index: index));
         } finally {
           _seeking = false;
         }
@@ -1093,7 +1149,8 @@ class AudioPlayer {
 
   /// Set the Android audio attributes for this player. Has no effect on other
   /// platforms. This will cause a new Android AudioSession ID to be generated.
-  Future<void> setAndroidAudioAttributes(AndroidAudioAttributes audioAttributes) async {
+  Future<void> setAndroidAudioAttributes(
+      AndroidAudioAttributes audioAttributes) async {
     if (_disposed) return;
     if (!_isAndroid() && !_isUnitTest()) return;
     if (audioAttributes == _androidAudioAttributes) return;
@@ -1101,8 +1158,8 @@ class AudioPlayer {
     await _internalSetAndroidAudioAttributes(await _platform, audioAttributes);
   }
 
-  Future<void> _internalSetAndroidAudioAttributes(
-      AudioPlayerPlatform platform, AndroidAudioAttributes audioAttributes) async {
+  Future<void> _internalSetAndroidAudioAttributes(AudioPlayerPlatform platform,
+      AndroidAudioAttributes audioAttributes) async {
     if (!_isAndroid() && !_isUnitTest()) return;
     await platform.setAndroidAudioAttributes(SetAndroidAudioAttributesRequest(
         contentType: audioAttributes.contentType.index,
@@ -1147,7 +1204,8 @@ class AudioPlayer {
   ///
   /// The platform will not switch if [active] == [_active] unless [force] is
   /// `true`.
-  Future<Duration?>? _setPlatformActive(bool active, {Completer<void>? playCompleter, bool force = false}) {
+  Future<Duration?>? _setPlatformActive(bool active,
+      {Completer<void>? playCompleter, bool force = false}) {
     if (_disposed) return null;
     if (!force && (active == _active)) return _durationFuture;
     _platformLoading = active;
@@ -1183,7 +1241,8 @@ class AudioPlayer {
       // An interruption that we can ignore
       if (!active) return true;
       // An interruption that should throw
-      final e = PlatformException(code: 'abort', message: 'Loading interrupted');
+      final e =
+          PlatformException(code: 'abort', message: 'Loading interrupted');
       durationCompleter.completeError(e);
       throw e;
     }
@@ -1196,7 +1255,8 @@ class AudioPlayer {
     final audioSource = _audioSource;
 
     void subscribeToEvents(AudioPlayerPlatform platform) {
-      _playerDataSubscription = platform.playerDataMessageStream.listen((message) {
+      _playerDataSubscription =
+          platform.playerDataMessageStream.listen((message) {
         if (message.playing != null && message.playing != playing) {
           _playingSubject.add(message.playing!);
         }
@@ -1213,10 +1273,12 @@ class AudioPlayer {
           _loopModeSubject.add(LoopMode.values[message.loopMode!.index]);
         }
         if (message.shuffleMode != null) {
-          _shuffleModeEnabledSubject.add(message.shuffleMode != ShuffleModeMessage.none);
+          _shuffleModeEnabledSubject
+              .add(message.shuffleMode != ShuffleModeMessage.none);
         }
       });
-      _playbackEventSubscription = platform.playbackEventMessageStream.listen((message) {
+      _playbackEventSubscription =
+          platform.playbackEventMessageStream.listen((message) {
         var duration = message.duration;
         var index = message.currentIndex ?? currentIndex;
         if (index != null && sequence != null && index < sequence!.length) {
@@ -1226,19 +1288,23 @@ class AudioPlayer {
             sequence![index].duration = duration;
           }
         }
-        if (_platformLoading && message.processingState != ProcessingStateMessage.idle) {
+        if (_platformLoading &&
+            message.processingState != ProcessingStateMessage.idle) {
           _platformLoading = false;
         }
         final playbackEvent = PlaybackEvent(
           // The platform may emit an idle state while it's starting up which we
           // override here.
-          processingState:
-              _platformLoading ? ProcessingState.loading : ProcessingState.values[message.processingState.index],
+          processingState: _platformLoading
+              ? ProcessingState.loading
+              : ProcessingState.values[message.processingState.index],
           updateTime: message.updateTime,
           updatePosition: message.updatePosition,
           bufferedPosition: message.bufferedPosition,
           duration: duration,
-          icyMetadata: message.icyMetadata == null ? null : IcyMetadata._fromMessage(message.icyMetadata!),
+          icyMetadata: message.icyMetadata == null
+              ? null
+              : IcyMetadata._fromMessage(message.icyMetadata!),
           currentIndex: index,
           androidAudioSessionId: message.androidAudioSessionId,
         );
@@ -1251,7 +1317,8 @@ class AudioPlayer {
         }
         final oldPlaybackEvent = _playbackEvent;
         _playbackEventSubject.add(_playbackEvent = playbackEvent);
-        if (_playbackEvent.processingState != oldPlaybackEvent.processingState &&
+        if (_playbackEvent.processingState !=
+                oldPlaybackEvent.processingState &&
             _playbackEvent.processingState == ProcessingState.idle) {
           _setPlatformActive(false)?.catchError((dynamic e) async => null);
         }
@@ -1275,14 +1342,19 @@ class AudioPlayer {
               id: _id,
               audioLoadConfiguration: _audioLoadConfiguration?._toMessage(),
               androidAudioEffects: (_isAndroid() || _isUnitTest())
-                  ? _audioPipeline.androidAudioEffects.map((audioEffect) => audioEffect._toMessage()).toList()
+                  ? _audioPipeline.androidAudioEffects
+                      .map((audioEffect) => audioEffect._toMessage())
+                      .toList()
                   : [],
               darwinAudioEffects: (_isDarwin() || _isUnitTest())
-                  ? _audioPipeline.darwinAudioEffects.map((audioEffect) => audioEffect._toMessage()).toList()
+                  ? _audioPipeline.darwinAudioEffects
+                      .map((audioEffect) => audioEffect._toMessage())
+                      .toList()
                   : [],
               androidOffloadSchedulingEnabled: _androidOffloadSchedulingEnabled,
             )))
-          : (_idlePlatform = _IdleAudioPlayer(id: _id, sequenceStream: sequenceStream));
+          : (_idlePlatform =
+              _IdleAudioPlayer(id: _id, sequenceStream: sequenceStream));
       if (checkInterruption()) return platform;
 
       _platformValue = platform;
@@ -1295,7 +1367,8 @@ class AudioPlayer {
           ));
         }
 
-        final automaticallyWaitsToMinimizeStalling = this.automaticallyWaitsToMinimizeStalling;
+        final automaticallyWaitsToMinimizeStalling =
+            this.automaticallyWaitsToMinimizeStalling;
         final playing = this.playing;
         // To avoid a glitch in ExoPlayer, ensure that any requested audio
         // attributes are set before loading the audio source.
@@ -1303,17 +1376,20 @@ class AudioPlayer {
           if (_androidApplyAudioAttributes) {
             final audioSession = await AudioSession.instance;
             if (checkInterruption()) return platform;
-            _androidAudioAttributes ??= audioSession.configuration?.androidAudioAttributes;
+            _androidAudioAttributes ??=
+                audioSession.configuration?.androidAudioAttributes;
           }
           if (_androidAudioAttributes != null) {
-            await _internalSetAndroidAudioAttributes(platform, _androidAudioAttributes!);
+            await _internalSetAndroidAudioAttributes(
+                platform, _androidAudioAttributes!);
             if (checkInterruption()) return platform;
           }
         }
         if (!automaticallyWaitsToMinimizeStalling) {
           // Only set if different from default.
           await platform.setAutomaticallyWaitsToMinimizeStalling(
-              SetAutomaticallyWaitsToMinimizeStallingRequest(enabled: automaticallyWaitsToMinimizeStalling));
+              SetAutomaticallyWaitsToMinimizeStallingRequest(
+                  enabled: automaticallyWaitsToMinimizeStalling));
           if (checkInterruption()) return platform;
         }
         await platform.setVolume(SetVolumeRequest(volume: volume));
@@ -1327,15 +1403,19 @@ class AudioPlayer {
         }
         if (checkInterruption()) return platform;
         try {
-          await platform.setSkipSilence(SetSkipSilenceRequest(enabled: skipSilenceEnabled));
+          await platform.setSkipSilence(
+              SetSkipSilenceRequest(enabled: skipSilenceEnabled));
         } catch (e) {
           // setSkipSilence not supported on this platform.
         }
         if (checkInterruption()) return platform;
-        await platform.setLoopMode(SetLoopModeRequest(loopMode: LoopModeMessage.values[loopMode.index]));
+        await platform.setLoopMode(SetLoopModeRequest(
+            loopMode: LoopModeMessage.values[loopMode.index]));
         if (checkInterruption()) return platform;
-        await platform.setShuffleMode(
-            SetShuffleModeRequest(shuffleMode: shuffleModeEnabled ? ShuffleModeMessage.all : ShuffleModeMessage.none));
+        await platform.setShuffleMode(SetShuffleModeRequest(
+            shuffleMode: shuffleModeEnabled
+                ? ShuffleModeMessage.all
+                : ShuffleModeMessage.none));
         if (checkInterruption()) return platform;
         for (var audioEffect in _audioPipeline._audioEffects) {
           await audioEffect._activate(platform);
@@ -1350,13 +1430,16 @@ class AudioPlayer {
 
       if (audioSource != null) {
         try {
-          final initialSeekValues = _initialSeekValues ?? _InitialSeekValues(position: position, index: currentIndex);
+          final initialSeekValues = _initialSeekValues ??
+              _InitialSeekValues(position: position, index: currentIndex);
           _initialSeekValues = null;
-          final duration = await _load(platform, _audioSource!, initialSeekValues: initialSeekValues);
+          final duration = await _load(platform, _audioSource!,
+              initialSeekValues: initialSeekValues);
           if (checkInterruption()) return platform;
           durationCompleter.complete(duration);
         } catch (e, stackTrace) {
-          await _setPlatformActive(false)?.catchError((dynamic e) async => null);
+          await _setPlatformActive(false)
+              ?.catchError((dynamic e) async => null);
           durationCompleter.completeError(e, stackTrace);
         }
       } else {
@@ -1483,7 +1566,8 @@ class PlaybackEvent {
         duration: duration ?? this.duration,
         icyMetadata: icyMetadata ?? this.icyMetadata,
         currentIndex: currentIndex ?? this.currentIndex,
-        androidAudioSessionId: androidAudioSessionId ?? this.androidAudioSessionId,
+        androidAudioSessionId:
+            androidAudioSessionId ?? this.androidAudioSessionId,
       );
 
   @override
@@ -1581,7 +1665,10 @@ class IcyInfo {
 
   @override
   bool operator ==(Object other) =>
-      other.runtimeType == runtimeType && other is IcyInfo && other.title == title && other.url == url;
+      other.runtimeType == runtimeType &&
+      other is IcyInfo &&
+      other.title == title &&
+      other.url == url;
 }
 
 class IcyHeaders {
@@ -1635,7 +1722,9 @@ class IcyMetadata {
 
   static IcyMetadata _fromMessage(IcyMetadataMessage message) => IcyMetadata(
         info: message.info == null ? null : IcyInfo._fromMessage(message.info!),
-        headers: message.headers == null ? null : IcyHeaders._fromMessage(message.headers!),
+        headers: message.headers == null
+            ? null
+            : IcyHeaders._fromMessage(message.headers!),
       );
 
   IcyMetadata({required this.info, required this.headers});
@@ -1645,7 +1734,10 @@ class IcyMetadata {
 
   @override
   bool operator ==(Object other) =>
-      other.runtimeType == runtimeType && other is IcyMetadata && other.info == info && other.headers == headers;
+      other.runtimeType == runtimeType &&
+      other is IcyMetadata &&
+      other.info == info &&
+      other.headers == headers;
 }
 
 /// Encapsulates the [sequence] and [currentIndex] state and ensures
@@ -1668,15 +1760,18 @@ class SequenceState {
   /// The current loop mode.
   final LoopMode loopMode;
 
-  SequenceState(this.sequence, this.currentIndex, this.shuffleIndices, this.shuffleModeEnabled, this.loopMode);
+  SequenceState(this.sequence, this.currentIndex, this.shuffleIndices,
+      this.shuffleModeEnabled, this.loopMode);
 
   /// The current source in the sequence.
-  IndexedAudioSource? get currentSource => sequence.isEmpty ? null : sequence[currentIndex];
+  IndexedAudioSource? get currentSource =>
+      sequence.isEmpty ? null : sequence[currentIndex];
 
   /// The effective sequence. This is equivalent to [sequence]. If
   /// [shuffleModeEnabled] is true, this is modulated by [shuffleIndices].
-  List<IndexedAudioSource> get effectiveSequence =>
-      shuffleModeEnabled ? shuffleIndices.map((i) => sequence[i]).toList() : sequence;
+  List<IndexedAudioSource> get effectiveSequence => shuffleModeEnabled
+      ? shuffleIndices.map((i) => sequence[i]).toList()
+      : sequence;
 }
 
 /// Configuration options to use when loading audio from a source.
@@ -1699,7 +1794,8 @@ class AudioLoadConfiguration {
   AudioLoadConfigurationMessage _toMessage() => AudioLoadConfigurationMessage(
         darwinLoadControl: darwinLoadControl?._toMessage(),
         androidLoadControl: androidLoadControl?._toMessage(),
-        androidLivePlaybackSpeedControl: androidLivePlaybackSpeedControl?._toMessage(),
+        androidLivePlaybackSpeedControl:
+            androidLivePlaybackSpeedControl?._toMessage(),
       );
 }
 
@@ -1730,9 +1826,11 @@ class DarwinLoadControl {
   });
 
   DarwinLoadControlMessage _toMessage() => DarwinLoadControlMessage(
-        automaticallyWaitsToMinimizeStalling: automaticallyWaitsToMinimizeStalling,
+        automaticallyWaitsToMinimizeStalling:
+            automaticallyWaitsToMinimizeStalling,
         preferredForwardBufferDuration: preferredForwardBufferDuration,
-        canUseNetworkResourcesForLiveStreamingWhilePaused: canUseNetworkResourcesForLiveStreamingWhilePaused,
+        canUseNetworkResourcesForLiveStreamingWhilePaused:
+            canUseNetworkResourcesForLiveStreamingWhilePaused,
         preferredPeakBitRate: preferredPeakBitRate,
       );
 }
@@ -1779,7 +1877,8 @@ class AndroidLoadControl {
         minBufferDuration: minBufferDuration,
         maxBufferDuration: maxBufferDuration,
         bufferForPlaybackDuration: bufferForPlaybackDuration,
-        bufferForPlaybackAfterRebufferDuration: bufferForPlaybackAfterRebufferDuration,
+        bufferForPlaybackAfterRebufferDuration:
+            bufferForPlaybackAfterRebufferDuration,
         targetBufferBytes: targetBufferBytes,
         prioritizeTimeOverSizeThresholds: prioritizeTimeOverSizeThresholds,
         backBufferDuration: backBufferDuration,
@@ -1823,18 +1922,22 @@ class AndroidLivePlaybackSpeedControl {
     this.minUpdateInterval = const Duration(seconds: 1),
     this.proportionalControlFactor = 1.0,
     this.maxLiveOffsetErrorForUnitSpeed = const Duration(milliseconds: 20),
-    this.targetLiveOffsetIncrementOnRebuffer = const Duration(milliseconds: 500),
+    this.targetLiveOffsetIncrementOnRebuffer =
+        const Duration(milliseconds: 500),
     this.minPossibleLiveOffsetSmoothingFactor = 0.999,
   });
 
-  AndroidLivePlaybackSpeedControlMessage _toMessage() => AndroidLivePlaybackSpeedControlMessage(
+  AndroidLivePlaybackSpeedControlMessage _toMessage() =>
+      AndroidLivePlaybackSpeedControlMessage(
         fallbackMinPlaybackSpeed: fallbackMinPlaybackSpeed,
         fallbackMaxPlaybackSpeed: fallbackMaxPlaybackSpeed,
         minUpdateInterval: minUpdateInterval,
         proportionalControlFactor: proportionalControlFactor,
         maxLiveOffsetErrorForUnitSpeed: maxLiveOffsetErrorForUnitSpeed,
-        targetLiveOffsetIncrementOnRebuffer: targetLiveOffsetIncrementOnRebuffer,
-        minPossibleLiveOffsetSmoothingFactor: minPossibleLiveOffsetSmoothingFactor,
+        targetLiveOffsetIncrementOnRebuffer:
+            targetLiveOffsetIncrementOnRebuffer,
+        minPossibleLiveOffsetSmoothingFactor:
+            minPossibleLiveOffsetSmoothingFactor,
       );
 }
 
@@ -1880,8 +1983,8 @@ class _ProxyHttpServer {
     return uri;
   }
 
-  Uri _sourceUri(StreamAudioSource source) =>
-      Uri.http('${InternetAddress.loopbackIPv4.address}:$port', '/id/${source._id}');
+  Uri _sourceUri(StreamAudioSource source) => Uri.http(
+      '${InternetAddress.loopbackIPv4.address}:$port', '/id/${source._id}');
 
   /// A unique key for each request that can be processed by this proxy,
   /// made up of the URL path and query string. It is not possible to
@@ -1935,7 +2038,8 @@ class _HttpRangeRequest {
   _HttpRangeRequest(this.start, this.end);
 
   /// Format a range header for this request.
-  String get header => 'bytes=$start-${end != null ? (end! - 1).toString() : ""}';
+  String get header =>
+      'bytes=$start-${end != null ? (end! - 1).toString() : ""}';
 
   /// Creates an [_HttpRangeRequest] from [header].
   static _HttpRangeRequest? parse(List<String>? header) {
@@ -1990,9 +2094,11 @@ abstract class AudioSource {
   ///
   /// If headers are set, just_audio will create a cleartext local HTTP proxy on
   /// your device to forward HTTP requests with headers included.
-  static UriAudioSource uri(Uri uri, {Map<String, String>? headers, dynamic tag}) {
+  static UriAudioSource uri(Uri uri,
+      {Map<String, String>? headers, dynamic tag}) {
     bool hasExtension(Uri uri, String extension) =>
-        uri.path.toLowerCase().endsWith('.$extension') || uri.fragment.toLowerCase().endsWith('.$extension');
+        uri.path.toLowerCase().endsWith('.$extension') ||
+        uri.fragment.toLowerCase().endsWith('.$extension');
     if (hasExtension(uri, 'mpd')) {
       return DashAudioSource(uri, headers: headers, tag: tag);
     } else if (hasExtension(uri, 'm3u8')) {
@@ -2023,8 +2129,10 @@ abstract class AudioSource {
   ///
   /// If the asset is to be loaded from a different package, the [package]
   /// parameter must be given to specify the package name.
-  static UriAudioSource asset(String assetPath, {String? package, dynamic tag}) {
-    final keyName = package == null ? assetPath : 'packages/$package/$assetPath';
+  static UriAudioSource asset(String assetPath,
+      {String? package, dynamic tag}) {
+    final keyName =
+        package == null ? assetPath : 'packages/$package/$assetPath';
     return AudioSource.uri(Uri.parse('asset:///$keyName'), tag: tag);
   }
 
@@ -2054,7 +2162,10 @@ abstract class AudioSource {
   int get hashCode => _id.hashCode;
 
   @override
-  bool operator ==(Object other) => other.runtimeType == runtimeType && other is AudioSource && other._id == _id;
+  bool operator ==(Object other) =>
+      other.runtimeType == runtimeType &&
+      other is AudioSource &&
+      other._id == _id;
 }
 
 /// An [AudioSource] that can appear in a sequence.
@@ -2080,7 +2191,8 @@ abstract class UriAudioSource extends IndexedAudioSource {
   final Map<String, String>? headers;
   Uri? _overrideUri;
 
-  UriAudioSource(this.uri, {this.headers, dynamic tag, Duration? duration}) : super(tag: tag, duration: duration);
+  UriAudioSource(this.uri, {this.headers, dynamic tag, Duration? duration})
+      : super(tag: tag, duration: duration);
 
   /// If [uri] points to an asset, this gives us [_overrideUri] which is the URI
   /// of the copied asset on the filesystem, otherwise it gives us the original
@@ -2092,7 +2204,9 @@ abstract class UriAudioSource extends IndexedAudioSource {
     await super._setup(player);
     if (uri.scheme == 'asset') {
       _overrideUri = await _loadAsset(uri.pathSegments.join('/'));
-    } else if (uri.scheme != 'file' && !kIsWeb && (headers != null || player._userAgent != null)) {
+    } else if (uri.scheme != 'file' &&
+        !kIsWeb &&
+        (headers != null || player._userAgent != null)) {
       await player._proxy.ensureRunning();
       _overrideUri = player._proxy.addUriAudioSource(this);
     }
@@ -2117,8 +2231,12 @@ abstract class UriAudioSource extends IndexedAudioSource {
         '.m3u': 'audio/x-mpegurl',
       };
       // Default to 'audio/mpeg'
-      final mimeType = mimeTypes[p.extension(assetPath).toLowerCase()] ?? 'audio/mpeg';
-      return _encodeDataUrl(base64.encode((await rootBundle.load(assetPath)).buffer.asUint8List()), mimeType);
+      final mimeType =
+          mimeTypes[p.extension(assetPath).toLowerCase()] ?? 'audio/mpeg';
+      return _encodeDataUrl(
+          base64
+              .encode((await rootBundle.load(assetPath)).buffer.asUint8List()),
+          mimeType);
     } else {
       // For non-web platforms, extract the asset into a cache file and pass
       // that to the player.
@@ -2127,7 +2245,8 @@ abstract class UriAudioSource extends IndexedAudioSource {
       // locking the file or creating a separate lock file.
       if (!file.existsSync()) {
         file.createSync(recursive: true);
-        await file.writeAsBytes((await rootBundle.load(assetPath)).buffer.asUint8List());
+        await file.writeAsBytes(
+            (await rootBundle.load(assetPath)).buffer.asUint8List());
       }
       return Uri.file(file.path);
     }
@@ -2155,12 +2274,13 @@ abstract class UriAudioSource extends IndexedAudioSource {
 /// If headers are set, just_audio will create a cleartext local HTTP proxy on
 /// your device to forward HTTP requests with headers included.
 class ProgressiveAudioSource extends UriAudioSource {
-  ProgressiveAudioSource(Uri uri, {Map<String, String>? headers, dynamic tag, Duration? duration})
+  ProgressiveAudioSource(Uri uri,
+      {Map<String, String>? headers, dynamic tag, Duration? duration})
       : super(uri, headers: headers, tag: tag, duration: duration);
 
   @override
-  AudioSourceMessage _toMessage() =>
-      ProgressiveAudioSourceMessage(id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
+  AudioSourceMessage _toMessage() => ProgressiveAudioSourceMessage(
+      id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
 }
 
 /// An [AudioSource] representing a DASH stream. The following URI schemes are
@@ -2178,12 +2298,13 @@ class ProgressiveAudioSource extends UriAudioSource {
 /// If headers are set, just_audio will create a cleartext local HTTP proxy on
 /// your device to forward HTTP requests with headers included.
 class DashAudioSource extends UriAudioSource {
-  DashAudioSource(Uri uri, {Map<String, String>? headers, dynamic tag, Duration? duration})
+  DashAudioSource(Uri uri,
+      {Map<String, String>? headers, dynamic tag, Duration? duration})
       : super(uri, headers: headers, tag: tag, duration: duration);
 
   @override
-  AudioSourceMessage _toMessage() =>
-      DashAudioSourceMessage(id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
+  AudioSourceMessage _toMessage() => DashAudioSourceMessage(
+      id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
 }
 
 /// An [AudioSource] representing an HLS stream. The following URI schemes are
@@ -2200,12 +2321,13 @@ class DashAudioSource extends UriAudioSource {
 /// If headers are set, just_audio will create a cleartext local HTTP proxy on
 /// your device to forward HTTP requests with headers included.
 class HlsAudioSource extends UriAudioSource {
-  HlsAudioSource(Uri uri, {Map<String, String>? headers, dynamic tag, Duration? duration})
+  HlsAudioSource(Uri uri,
+      {Map<String, String>? headers, dynamic tag, Duration? duration})
       : super(uri, headers: headers, tag: tag, duration: duration);
 
   @override
-  AudioSourceMessage _toMessage() =>
-      HlsAudioSourceMessage(id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
+  AudioSourceMessage _toMessage() => HlsAudioSourceMessage(
+      id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
 }
 
 /// An [AudioSource] for a period of silence.
@@ -2224,7 +2346,8 @@ class SilenceAudioSource extends IndexedAudioSource {
   }) : super(tag: tag, duration: duration);
 
   @override
-  AudioSourceMessage _toMessage() => SilenceAudioSourceMessage(id: _id, duration: duration);
+  AudioSourceMessage _toMessage() =>
+      SilenceAudioSourceMessage(id: _id, duration: duration);
 }
 
 /// An [AudioSource] representing a concatenation of multiple audio sources to
@@ -2268,11 +2391,14 @@ class ConcatenatingAudioSource extends AudioSource {
     for (var ci = 0, si = 0; ci < children.length; ci++) {
       final child = children[ci];
       final childLength = child.sequence.length;
-      final initialIndexWithinThisChild = initialIndex != null && initialIndex >= si && initialIndex < si + childLength;
+      final initialIndexWithinThisChild = initialIndex != null &&
+          initialIndex >= si &&
+          initialIndex < si + childLength;
       if (initialIndexWithinThisChild) {
         localInitialIndex = ci;
       }
-      final childInitialIndex = initialIndexWithinThisChild ? (initialIndex! - si) : null;
+      final childInitialIndex =
+          initialIndexWithinThisChild ? (initialIndex! - si) : null;
       child._shuffle(initialIndex: childInitialIndex);
       si += childLength;
     }
@@ -2287,8 +2413,12 @@ class ConcatenatingAudioSource extends AudioSource {
     if (_player != null) {
       _player!._broadcastSequence();
       await audioSource._setup(_player!);
-      await (await _player!._platform).concatenatingInsertAll(ConcatenatingInsertAllRequest(
-          id: _id, index: index, children: [audioSource._toMessage()], shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingInsertAll(
+          ConcatenatingInsertAllRequest(
+              id: _id,
+              index: index,
+              children: [audioSource._toMessage()],
+              shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2299,8 +2429,12 @@ class ConcatenatingAudioSource extends AudioSource {
     if (_player != null) {
       _player!._broadcastSequence();
       await audioSource._setup(_player!);
-      await (await _player!._platform).concatenatingInsertAll(ConcatenatingInsertAllRequest(
-          id: _id, index: index, children: [audioSource._toMessage()], shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingInsertAll(
+          ConcatenatingInsertAllRequest(
+              id: _id,
+              index: index,
+              children: [audioSource._toMessage()],
+              shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2314,11 +2448,12 @@ class ConcatenatingAudioSource extends AudioSource {
       for (var child in children) {
         await child._setup(_player!);
       }
-      await (await _player!._platform).concatenatingInsertAll(ConcatenatingInsertAllRequest(
-          id: _id,
-          index: index,
-          children: children.map((child) => child._toMessage()).toList(),
-          shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingInsertAll(
+          ConcatenatingInsertAllRequest(
+              id: _id,
+              index: index,
+              children: children.map((child) => child._toMessage()).toList(),
+              shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2331,11 +2466,12 @@ class ConcatenatingAudioSource extends AudioSource {
       for (var child in children) {
         await child._setup(_player!);
       }
-      await (await _player!._platform).concatenatingInsertAll(ConcatenatingInsertAllRequest(
-          id: _id,
-          index: index,
-          children: children.map((child) => child._toMessage()).toList(),
-          shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingInsertAll(
+          ConcatenatingInsertAllRequest(
+              id: _id,
+              index: index,
+              children: children.map((child) => child._toMessage()).toList(),
+              shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2346,8 +2482,12 @@ class ConcatenatingAudioSource extends AudioSource {
     _shuffleOrder.removeRange(index, index + 1);
     if (_player != null) {
       _player!._broadcastSequence();
-      await (await _player!._platform).concatenatingRemoveRange(ConcatenatingRemoveRangeRequest(
-          id: _id, startIndex: index, endIndex: index + 1, shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingRemoveRange(
+          ConcatenatingRemoveRangeRequest(
+              id: _id,
+              startIndex: index,
+              endIndex: index + 1,
+              shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2358,8 +2498,12 @@ class ConcatenatingAudioSource extends AudioSource {
     _shuffleOrder.removeRange(start, end);
     if (_player != null) {
       _player!._broadcastSequence();
-      await (await _player!._platform).concatenatingRemoveRange(ConcatenatingRemoveRangeRequest(
-          id: _id, startIndex: start, endIndex: end, shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingRemoveRange(
+          ConcatenatingRemoveRangeRequest(
+              id: _id,
+              startIndex: start,
+              endIndex: end,
+              shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2370,8 +2514,12 @@ class ConcatenatingAudioSource extends AudioSource {
     _shuffleOrder.insert(newIndex, 1);
     if (_player != null) {
       _player!._broadcastSequence();
-      await (await _player!._platform).concatenatingMove(ConcatenatingMoveRequest(
-          id: _id, currentIndex: currentIndex, newIndex: newIndex, shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingMove(
+          ConcatenatingMoveRequest(
+              id: _id,
+              currentIndex: currentIndex,
+              newIndex: newIndex,
+              shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2382,8 +2530,12 @@ class ConcatenatingAudioSource extends AudioSource {
     _shuffleOrder.clear();
     if (_player != null) {
       _player!._broadcastSequence();
-      await (await _player!._platform).concatenatingRemoveRange(ConcatenatingRemoveRangeRequest(
-          id: _id, startIndex: 0, endIndex: end, shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingRemoveRange(
+          ConcatenatingRemoveRangeRequest(
+              id: _id,
+              startIndex: 0,
+              endIndex: end,
+              shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2393,7 +2545,8 @@ class ConcatenatingAudioSource extends AudioSource {
   AudioSource operator [](int index) => children[index];
 
   @override
-  List<IndexedAudioSource> get sequence => children.expand((s) => s.sequence).toList();
+  List<IndexedAudioSource> get sequence =>
+      children.expand((s) => s.sequence).toList();
 
   @override
   List<int> get shuffleIndices {
@@ -2445,7 +2598,11 @@ class ClippingAudioSource extends IndexedAudioSource {
 
   @override
   AudioSourceMessage _toMessage() => ClippingAudioSourceMessage(
-      id: _id, child: child._toMessage() as UriAudioSourceMessage, start: start, end: end, tag: tag);
+      id: _id,
+      child: child._toMessage() as UriAudioSourceMessage,
+      start: start,
+      end: end,
+      tag: tag);
 }
 
 // An [AudioSource] that loops a nested [AudioSource] a finite number of times.
@@ -2470,16 +2627,19 @@ class LoopingAudioSource extends AudioSource {
   void _shuffle({int? initialIndex}) {}
 
   @override
-  List<IndexedAudioSource> get sequence => List.generate(count, (i) => child).expand((s) => s.sequence).toList();
+  List<IndexedAudioSource> get sequence =>
+      List.generate(count, (i) => child).expand((s) => s.sequence).toList();
 
   @override
   List<int> get shuffleIndices => List.generate(count, (i) => i);
 
   @override
-  AudioSourceMessage _toMessage() => LoopingAudioSourceMessage(id: _id, child: child._toMessage(), count: count);
+  AudioSourceMessage _toMessage() => LoopingAudioSourceMessage(
+      id: _id, child: child._toMessage(), count: count);
 }
 
-Uri _encodeDataUrl(String base64Data, String mimeType) => Uri.parse('data:$mimeType;base64,$base64Data');
+Uri _encodeDataUrl(String base64Data, String mimeType) =>
+    Uri.parse('data:$mimeType;base64,$base64Data');
 
 /// An [AudioSource] that provides audio dynamically. Subclasses must override
 /// [request] to provide the encoded audio data. This API is experimental.
@@ -2493,7 +2653,8 @@ abstract class StreamAudioSource extends IndexedAudioSource {
     await super._setup(player);
     if (kIsWeb) {
       final response = await request();
-      _uri = _encodeDataUrl(await base64.encoder.bind(response.stream).join(), response.contentType);
+      _uri = _encodeDataUrl(await base64.encoder.bind(response.stream).join(),
+          response.contentType);
     } else {
       await player._proxy.ensureRunning();
       _uri = player._proxy.addStreamAudioSource(this);
@@ -2508,8 +2669,8 @@ abstract class StreamAudioSource extends IndexedAudioSource {
   Future<StreamAudioResponse> request([int? start, int? end]);
 
   @override
-  AudioSourceMessage _toMessage() =>
-      ProgressiveAudioSourceMessage(id: _id, uri: _uri.toString(), headers: null, tag: tag);
+  AudioSourceMessage _toMessage() => ProgressiveAudioSourceMessage(
+      id: _id, uri: _uri.toString(), headers: null, tag: tag);
 }
 
 /// The response for a [StreamAudioSource]. This API is experimental.
@@ -2575,7 +2736,8 @@ class LockCachingAudioSource extends StreamAudioSource {
     this.headers,
     File? cacheFile,
     dynamic tag,
-  })  : cacheFile = cacheFile != null ? Future.value(cacheFile) : _getCacheFile(uri),
+  })  : cacheFile =
+            cacheFile != null ? Future.value(cacheFile) : _getCacheFile(uri),
         super(tag: tag) {
     _init();
   }
@@ -2619,10 +2781,12 @@ class LockCachingAudioSource extends StreamAudioSource {
   static Future<File> _getCacheFile(final Uri uri) async => File(p.joinAll([
         (await _getCacheDir()).path,
         'remote',
-        sha256.convert(utf8.encode(uri.toString())).toString() + p.extension(uri.path),
+        sha256.convert(utf8.encode(uri.toString())).toString() +
+            p.extension(uri.path),
       ]));
 
-  Future<File> get _partialCacheFile async => File('${(await cacheFile).path}.part');
+  Future<File> get _partialCacheFile async =>
+      File('${(await cacheFile).path}.part');
 
   /// We use this to record the original content type of the downloaded audio.
   /// NOTE: We could instead rely on the cache file extension, but the original
@@ -2655,7 +2819,8 @@ class LockCachingAudioSource extends StreamAudioSource {
     final cacheFile = await this.cacheFile;
     final partialCacheFile = await _partialCacheFile;
 
-    File getEffectiveCacheFile() => partialCacheFile.existsSync() ? partialCacheFile : cacheFile;
+    File getEffectiveCacheFile() =>
+        partialCacheFile.existsSync() ? partialCacheFile : cacheFile;
 
     final httpClient = _createHttpClient(userAgent: _player?._userAgent);
     final httpRequest = await _getUrl(httpClient, uri, headers: headers);
@@ -2668,10 +2833,12 @@ class LockCachingAudioSource extends StreamAudioSource {
     // TODO: Should close sink after done, but it throws an error.
     // ignore: close_sinks
     final sink = (await _partialCacheFile).openWrite();
-    final sourceLength = response.contentLength == -1 ? null : response.contentLength;
+    final sourceLength =
+        response.contentLength == -1 ? null : response.contentLength;
     final mimeType = response.headers.contentType.toString();
     final acceptRanges = response.headers.value(HttpHeaders.acceptRangesHeader);
-    final originSupportsRangeRequests = acceptRanges != null && acceptRanges != 'none';
+    final originSupportsRangeRequests =
+        acceptRanges != null && acceptRanges != 'none';
     final mimeFile = await _mimeFile;
     await mimeFile.writeAsString(mimeType);
     final inProgressResponses = <_InProgressCacheResponse>[];
@@ -2695,17 +2862,24 @@ class LockCachingAudioSource extends StreamAudioSource {
       updateProgress(newPercentProgress);
       sink.add(data);
       final readyRequests = _requests
-          .where((request) => !originSupportsRangeRequests || request.start == null || (request.start!) < _progress)
+          .where((request) =>
+              !originSupportsRangeRequests ||
+              request.start == null ||
+              (request.start!) < _progress)
           .toList();
       final notReadyRequests = _requests
-          .where((request) => originSupportsRangeRequests && request.start != null && (request.start!) >= _progress)
+          .where((request) =>
+              originSupportsRangeRequests &&
+              request.start != null &&
+              (request.start!) >= _progress)
           .toList();
       // Add this live data to any responses in progress.
       for (var cacheResponse in inProgressResponses) {
         final end = cacheResponse.end;
         if (end != null && _progress >= end) {
           // We've received enough data to fulfill the byte range request.
-          final subEnd = min(data.length, max(0, data.length - (_progress - end)));
+          final subEnd =
+              min(data.length, max(0, data.length - (_progress - end)));
           cacheResponse.controller.add(data.sublist(0, subEnd));
           cacheResponse.controller.close();
         } else {
@@ -2734,7 +2908,8 @@ class LockCachingAudioSource extends StreamAudioSource {
         final effectiveEnd = end ?? sourceLength;
         Stream<List<int>> responseStream;
         if (effectiveEnd != null && effectiveEnd <= _progress) {
-          responseStream = getEffectiveCacheFile().openRead(effectiveStart, effectiveEnd);
+          responseStream =
+              getEffectiveCacheFile().openRead(effectiveStart, effectiveEnd);
         } else {
           final cacheResponse = _InProgressCacheResponse(end: effectiveEnd);
           inProgressResponses.add(cacheResponse);
@@ -2749,7 +2924,8 @@ class LockCachingAudioSource extends StreamAudioSource {
         request.complete(StreamAudioResponse(
           rangeRequestsSupported: originSupportsRangeRequests,
           sourceLength: start != null ? sourceLength : null,
-          contentLength: effectiveEnd != null ? effectiveEnd - effectiveStart : null,
+          contentLength:
+              effectiveEnd != null ? effectiveEnd - effectiveStart : null,
           offset: start,
           contentType: mimeType,
           stream: responseStream.asBroadcastStream(),
@@ -2840,7 +3016,8 @@ class LockCachingAudioSource extends StreamAudioSource {
     }
     final byteRangeRequest = _StreamingByteRangeRequest(start, end);
     _requests.add(byteRangeRequest);
-    _response ??= _fetch().catchError((dynamic error, StackTrace? stackTrace) async {
+    _response ??=
+        _fetch().catchError((dynamic error, StackTrace? stackTrace) async {
       // So that we can restart later
       _response = null;
       // Cancel any pending request
@@ -2917,19 +3094,22 @@ class _StreamingByteRangeRequest {
 }
 
 /// The type of functions that can handle HTTP requests sent to the proxy.
-typedef _ProxyHandler = void Function(_ProxyHttpServer server, HttpRequest request);
+typedef _ProxyHandler = void Function(
+    _ProxyHttpServer server, HttpRequest request);
 
 /// A proxy handler for serving audio from a [StreamAudioSource].
 _ProxyHandler _proxyHandlerForSource(StreamAudioSource source) {
   Future<void> handler(_ProxyHttpServer server, HttpRequest request) async {
-    final rangeRequest = _HttpRangeRequest.parse(request.headers[HttpHeaders.rangeHeader]);
+    final rangeRequest =
+        _HttpRangeRequest.parse(request.headers[HttpHeaders.rangeHeader]);
 
     request.response.headers.clear();
 
     StreamAudioResponse sourceResponse;
     Stream<List<int>> stream;
     try {
-      sourceResponse = await source.request(rangeRequest?.start, rangeRequest?.endEx);
+      sourceResponse =
+          await source.request(rangeRequest?.start, rangeRequest?.endEx);
       stream = sourceResponse.stream;
     } catch (e, st) {
       // ignore: avoid_print
@@ -2941,17 +3121,21 @@ _ProxyHandler _proxyHandlerForSource(StreamAudioSource source) {
       return;
     }
 
-    request.response.headers.set(HttpHeaders.contentTypeHeader, sourceResponse.contentType);
+    request.response.headers
+        .set(HttpHeaders.contentTypeHeader, sourceResponse.contentType);
 
     if (sourceResponse.rangeRequestsSupported) {
       request.response.headers.set(HttpHeaders.acceptRangesHeader, 'bytes');
     }
 
     if (rangeRequest != null && sourceResponse.offset != null) {
-      final range = _HttpRangeResponse(sourceResponse.offset!,
-          sourceResponse.offset! + sourceResponse.contentLength! - 1, sourceResponse.sourceLength);
+      final range = _HttpRangeResponse(
+          sourceResponse.offset!,
+          sourceResponse.offset! + sourceResponse.contentLength! - 1,
+          sourceResponse.sourceLength);
       request.response.contentLength = range.length ?? -1;
-      request.response.headers.set(HttpHeaders.contentRangeHeader, range.header);
+      request.response.headers
+          .set(HttpHeaders.contentRangeHeader, range.header);
       request.response.statusCode = 206;
     } else {
       request.response.contentLength = sourceResponse.contentLength ?? -1;
@@ -2993,8 +3177,10 @@ _ProxyHandler _proxyHandlerForUri(
     String? host;
     try {
       final requestHeaders = <String, String>{if (headers != null) ...headers};
-      request.headers.forEach((name, value) => requestHeaders[name] = value.join(', '));
-      final originRequest = await _getUrl(client, redirectedUri ?? uri, headers: requestHeaders);
+      request.headers
+          .forEach((name, value) => requestHeaders[name] = value.join(', '));
+      final originRequest =
+          await _getUrl(client, redirectedUri ?? uri, headers: requestHeaders);
       host = originRequest.headers.value(HttpHeaders.hostHeader);
       final originResponse = await originRequest.close();
       if (originResponse.redirects.isNotEmpty) {
@@ -3003,7 +3189,9 @@ _ProxyHandler _proxyHandlerForUri(
 
       request.response.headers.clear();
       originResponse.headers.forEach((name, value) {
-        final filteredValue = value.map((e) => e.replaceAll(RegExp(r'[^\x09\x20-\x7F]'), '?')).toList();
+        final filteredValue = value
+            .map((e) => e.replaceAll(RegExp(r'[^\x09\x20-\x7F]'), '?'))
+            .toList();
         request.response.headers.set(name, filteredValue);
       });
       request.response.statusCode = originResponse.statusCode;
@@ -3016,7 +3204,8 @@ _ProxyHandler _proxyHandlerForUri(
         // TODO: Handle other playlist formats similarly?
         final m3u8 = await originResponse.transform(utf8.decoder).join();
         for (var line in const LineSplitter().convert(m3u8)) {
-          line = line.replaceAllMapped(RegExp(r'#EXT-X-MEDIA:.*?URI="(.*?)".*'), (m) => m[1]!);
+          line = line.replaceAllMapped(
+              RegExp(r'#EXT-X-MEDIA:.*?URI="(.*?)".*'), (m) => m[1]!);
           line = line.replaceAll(RegExp(r'#.*$'), '').trim();
           if (line.isEmpty) continue;
           try {
@@ -3026,9 +3215,13 @@ _ProxyHandler _proxyHandlerForUri(
               server.addUriAudioSource(AudioSource.uri(rawNestedUri));
             } else {
               // This is a resource on the same server, so propagate the headers.
-              final basePath = rawNestedUri.path.startsWith('/') ? '' : uri.path.replaceAll(RegExp(r'/[^/]*$'), '/');
-              final nestedUri = uri.replace(path: '$basePath${rawNestedUri.path}');
-              server.addUriAudioSource(AudioSource.uri(nestedUri, headers: headers));
+              final basePath = rawNestedUri.path.startsWith('/')
+                  ? ''
+                  : uri.path.replaceAll(RegExp(r'/[^/]*$'), '/');
+              final nestedUri =
+                  uri.replace(path: '$basePath${rawNestedUri.path}');
+              server.addUriAudioSource(
+                  AudioSource.uri(nestedUri, headers: headers));
             }
           } catch (e) {
             // ignore malformed lines
@@ -3053,7 +3246,8 @@ _ProxyHandler _proxyHandlerForUri(
         // Try parsing HTTP 0.9 response
         //request.response.headers.clear();
         final socket = await Socket.connect(uri.host, uri.port);
-        final clientSocket = await request.response.detachSocket(writeHeaders: false);
+        final clientSocket =
+            await request.response.detachSocket(writeHeaders: false);
         final done = Completer<dynamic>();
         socket.listen(
           clientSocket.add,
@@ -3091,7 +3285,8 @@ _ProxyHandler _proxyHandlerForUri(
   return handler;
 }
 
-Future<Directory> _getCacheDir() async => Directory(p.join((await getTemporaryDirectory()).path, 'just_audio_cache'));
+Future<Directory> _getCacheDir() async =>
+    Directory(p.join((await getTemporaryDirectory()).path, 'just_audio_cache'));
 
 /// Defines the algorithm for shuffling the order of a
 /// [ConcatenatingAudioSource]. See [DefaultShuffleOrder] for a default
@@ -3214,10 +3409,13 @@ class _IdleAudioPlayer extends AudioPlayerPlatform {
   }
 
   Duration? _getDurationAtIndex(int? index) =>
-      index != null && _sequence != null && index < _sequence!.length ? _sequence![index].duration : null;
+      index != null && _sequence != null && index < _sequence!.length
+          ? _sequence![index].duration
+          : null;
 
   @override
-  Stream<PlaybackEventMessage> get playbackEventMessageStream => _eventSubject.stream;
+  Stream<PlaybackEventMessage> get playbackEventMessageStream =>
+      _eventSubject.stream;
 
   @override
   Future<LoadResponse> load(LoadRequest request) async {
@@ -3253,7 +3451,8 @@ class _IdleAudioPlayer extends AudioPlayerPlatform {
   }
 
   @override
-  Future<SetSkipSilenceResponse> setSkipSilence(SetSkipSilenceRequest request) async {
+  Future<SetSkipSilenceResponse> setSkipSilence(
+      SetSkipSilenceRequest request) async {
     return SetSkipSilenceResponse();
   }
 
@@ -3263,30 +3462,35 @@ class _IdleAudioPlayer extends AudioPlayerPlatform {
   }
 
   @override
-  Future<SetShuffleModeResponse> setShuffleMode(SetShuffleModeRequest request) async {
+  Future<SetShuffleModeResponse> setShuffleMode(
+      SetShuffleModeRequest request) async {
     return SetShuffleModeResponse();
   }
 
   @override
-  Future<SetShuffleOrderResponse> setShuffleOrder(SetShuffleOrderRequest request) async {
+  Future<SetShuffleOrderResponse> setShuffleOrder(
+      SetShuffleOrderRequest request) async {
     return SetShuffleOrderResponse();
   }
 
   @override
-  Future<SetAutomaticallyWaitsToMinimizeStallingResponse> setAutomaticallyWaitsToMinimizeStalling(
-      SetAutomaticallyWaitsToMinimizeStallingRequest request) async {
+  Future<SetAutomaticallyWaitsToMinimizeStallingResponse>
+      setAutomaticallyWaitsToMinimizeStalling(
+          SetAutomaticallyWaitsToMinimizeStallingRequest request) async {
     return SetAutomaticallyWaitsToMinimizeStallingResponse();
   }
 
   @override
   Future<SetCanUseNetworkResourcesForLiveStreamingWhilePausedResponse>
       setCanUseNetworkResourcesForLiveStreamingWhilePaused(
-          SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest request) async {
+          SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest
+              request) async {
     return SetCanUseNetworkResourcesForLiveStreamingWhilePausedResponse();
   }
 
   @override
-  Future<SetPreferredPeakBitRateResponse> setPreferredPeakBitRate(SetPreferredPeakBitRateRequest request) async {
+  Future<SetPreferredPeakBitRateResponse> setPreferredPeakBitRate(
+      SetPreferredPeakBitRateRequest request) async {
     return SetPreferredPeakBitRateResponse();
   }
 
@@ -3299,7 +3503,8 @@ class _IdleAudioPlayer extends AudioPlayerPlatform {
   }
 
   @override
-  Future<SetAndroidAudioAttributesResponse> setAndroidAudioAttributes(SetAndroidAudioAttributesRequest request) async {
+  Future<SetAndroidAudioAttributesResponse> setAndroidAudioAttributes(
+      SetAndroidAudioAttributesRequest request) async {
     setAndroidAudioAttributesRequest = request;
     return SetAndroidAudioAttributesResponse();
   }
@@ -3310,28 +3515,33 @@ class _IdleAudioPlayer extends AudioPlayerPlatform {
   }
 
   @override
-  Future<ConcatenatingInsertAllResponse> concatenatingInsertAll(ConcatenatingInsertAllRequest request) async {
+  Future<ConcatenatingInsertAllResponse> concatenatingInsertAll(
+      ConcatenatingInsertAllRequest request) async {
     return ConcatenatingInsertAllResponse();
   }
 
   @override
-  Future<ConcatenatingRemoveRangeResponse> concatenatingRemoveRange(ConcatenatingRemoveRangeRequest request) async {
+  Future<ConcatenatingRemoveRangeResponse> concatenatingRemoveRange(
+      ConcatenatingRemoveRangeRequest request) async {
     return ConcatenatingRemoveRangeResponse();
   }
 
   @override
-  Future<ConcatenatingMoveResponse> concatenatingMove(ConcatenatingMoveRequest request) async {
+  Future<ConcatenatingMoveResponse> concatenatingMove(
+      ConcatenatingMoveRequest request) async {
     return ConcatenatingMoveResponse();
   }
 
   @override
-  Future<AudioEffectSetEnabledResponse> audioEffectSetEnabled(AudioEffectSetEnabledRequest request) async {
+  Future<AudioEffectSetEnabledResponse> audioEffectSetEnabled(
+      AudioEffectSetEnabledRequest request) async {
     return AudioEffectSetEnabledResponse();
   }
 
   @override
-  Future<AndroidLoudnessEnhancerSetTargetGainResponse> androidLoudnessEnhancerSetTargetGain(
-      AndroidLoudnessEnhancerSetTargetGainRequest request) async {
+  Future<AndroidLoudnessEnhancerSetTargetGainResponse>
+      androidLoudnessEnhancerSetTargetGain(
+          AndroidLoudnessEnhancerSetTargetGainRequest request) async {
     return AndroidLoudnessEnhancerSetTargetGainResponse();
   }
 }
@@ -3352,12 +3562,15 @@ class AudioPipeline {
   AudioPipeline({
     List<AndroidAudioEffect>? androidAudioEffects,
     List<DarwinAudioEffect>? darwinAudioEffects,
-  })  : assert(androidAudioEffects == null || androidAudioEffects.toSet().length == androidAudioEffects.length),
-        assert(darwinAudioEffects == null || darwinAudioEffects.toSet().length == darwinAudioEffects.length),
+  })  : assert(androidAudioEffects == null ||
+            androidAudioEffects.toSet().length == androidAudioEffects.length),
+        assert(darwinAudioEffects == null ||
+            darwinAudioEffects.toSet().length == darwinAudioEffects.length),
         androidAudioEffects = androidAudioEffects ?? const [],
         darwinAudioEffects = darwinAudioEffects ?? const [];
 
-  List<AudioEffect> get _audioEffects => <AudioEffect>[...androidAudioEffects, ...darwinAudioEffects];
+  List<AudioEffect> get _audioEffects =>
+      <AudioEffect>[...androidAudioEffects, ...darwinAudioEffects];
 
   void _setup(AudioPlayer player) {
     for (var effect in _audioEffects) {
@@ -3405,8 +3618,8 @@ abstract class AudioEffect {
   Future<void> setEnabled(bool enabled) async {
     _enabledSubject.add(enabled);
     if (_active) {
-      await (await _player!._platform)
-          .audioEffectSetEnabled(AudioEffectSetEnabledRequest(type: _type, enabled: enabled));
+      await (await _player!._platform).audioEffectSetEnabled(
+          AudioEffectSetEnabledRequest(type: _type, enabled: enabled));
     }
   }
 
@@ -3437,8 +3650,8 @@ class AndroidLoudnessEnhancer extends AudioEffect with AndroidAudioEffect {
   Future<void> setTargetGain(double targetGain) async {
     _targetGainSubject.add(targetGain);
     if (_active) {
-      await (await _player!._platform)
-          .androidLoudnessEnhancerSetTargetGain(AndroidLoudnessEnhancerSetTargetGainRequest(targetGain: targetGain));
+      await (await _player!._platform).androidLoudnessEnhancerSetTargetGain(
+          AndroidLoudnessEnhancerSetTargetGainRequest(targetGain: targetGain));
     }
   }
 
@@ -3487,17 +3700,19 @@ class AndroidEqualizerBand {
   Future<void> setGain(double gain) async {
     _gainSubject.add(gain);
     if (_player._active) {
-      await (await _player._platform)
-          .androidEqualizerBandSetGain(AndroidEqualizerBandSetGainRequest(bandIndex: index, gain: gain));
+      await (await _player._platform).androidEqualizerBandSetGain(
+          AndroidEqualizerBandSetGainRequest(bandIndex: index, gain: gain));
     }
   }
 
   /// Restores the gain after reactivating.
   Future<void> _restore(AudioPlayerPlatform platform) async {
-    await (platform).androidEqualizerBandSetGain(AndroidEqualizerBandSetGainRequest(bandIndex: index, gain: gain));
+    await (platform).androidEqualizerBandSetGain(
+        AndroidEqualizerBandSetGainRequest(bandIndex: index, gain: gain));
   }
 
-  static AndroidEqualizerBand _fromMessage(AudioPlayer player, AndroidEqualizerBandMessage message) =>
+  static AndroidEqualizerBand _fromMessage(
+          AudioPlayer player, AndroidEqualizerBandMessage message) =>
       AndroidEqualizerBand._(
         player: player,
         index: message.index,
@@ -3532,18 +3747,23 @@ class AndroidEqualizerParameters {
     }
   }
 
-  static AndroidEqualizerParameters _fromMessage(AudioPlayer player, AndroidEqualizerParametersMessage message) =>
+  static AndroidEqualizerParameters _fromMessage(
+          AudioPlayer player, AndroidEqualizerParametersMessage message) =>
       AndroidEqualizerParameters(
         minDecibels: message.minDecibels,
         maxDecibels: message.maxDecibels,
-        bands: message.bands.map((bandMessage) => AndroidEqualizerBand._fromMessage(player, bandMessage)).toList(),
+        bands: message.bands
+            .map((bandMessage) =>
+                AndroidEqualizerBand._fromMessage(player, bandMessage))
+            .toList(),
       );
 }
 
 /// An [AudioEffect] for Android that can adjust the gain for different
 /// frequency bands of an [AudioPlayer]'s audio signal.
 class AndroidEqualizer extends AudioEffect with AndroidAudioEffect {
-  final Completer<AndroidEqualizerParameters> _parametersCompleter = Completer<AndroidEqualizerParameters>();
+  final Completer<AndroidEqualizerParameters> _parametersCompleter =
+      Completer<AndroidEqualizerParameters>();
 
   @override
   String get _type => 'AndroidEqualizer';
@@ -3555,13 +3775,16 @@ class AndroidEqualizer extends AudioEffect with AndroidAudioEffect {
       await (await parameters)._restore(platform);
       return;
     }
-    final response = await platform.androidEqualizerGetParameters(AndroidEqualizerGetParametersRequest());
-    final receivedParameters = AndroidEqualizerParameters._fromMessage(_player!, response.parameters);
+    final response = await platform
+        .androidEqualizerGetParameters(AndroidEqualizerGetParametersRequest());
+    final receivedParameters =
+        AndroidEqualizerParameters._fromMessage(_player!, response.parameters);
     _parametersCompleter.complete(receivedParameters);
   }
 
   /// The parameter values of this equalizer.
-  Future<AndroidEqualizerParameters> get parameters => _parametersCompleter.future;
+  Future<AndroidEqualizerParameters> get parameters =>
+      _parametersCompleter.future;
 
   @override
   AudioEffectMessage _toMessage() => AndroidEqualizerMessage(
@@ -3605,7 +3828,8 @@ enum PositionDiscontinuityReason {
   autoAdvance,
 }
 
-Future<HttpClientRequest> _getUrl(HttpClient client, Uri uri, {Map<String, String>? headers}) async {
+Future<HttpClientRequest> _getUrl(HttpClient client, Uri uri,
+    {Map<String, String>? headers}) async {
   final request = await client.getUrl(uri);
   if (headers != null) {
     final host = request.headers.value(HttpHeaders.hostHeader);

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -123,8 +123,7 @@ class AudioPlayer {
   final _loopModeSubject = BehaviorSubject.seeded(LoopMode.off);
   final _shuffleModeEnabledSubject = BehaviorSubject.seeded(false);
   final _androidAudioSessionIdSubject = BehaviorSubject<int?>();
-  final _positionDiscontinuitySubject =
-      PublishSubject<PositionDiscontinuity>(sync: true);
+  final _positionDiscontinuitySubject = PublishSubject<PositionDiscontinuity>(sync: true);
   var _seeking = false;
   // ignore: close_sinks
   BehaviorSubject<Duration>? _positionSubject;
@@ -174,16 +173,15 @@ class AudioPlayer {
     bool androidOffloadSchedulingEnabled = false,
   })  : _id = _uuid.v4(),
         _userAgent = userAgent,
-        _androidApplyAudioAttributes =
-            androidApplyAudioAttributes && _isAndroid(),
+        _androidApplyAudioAttributes = androidApplyAudioAttributes && _isAndroid(),
         _handleAudioSessionActivation = handleAudioSessionActivation,
         _audioLoadConfiguration = audioLoadConfiguration,
         _audioPipeline = audioPipeline ?? AudioPipeline(),
         _androidOffloadSchedulingEnabled = androidOffloadSchedulingEnabled {
     _audioPipeline._setup(this);
     if (_audioLoadConfiguration?.darwinLoadControl != null) {
-      _automaticallyWaitsToMinimizeStalling = _audioLoadConfiguration!
-          .darwinLoadControl!.automaticallyWaitsToMinimizeStalling;
+      _automaticallyWaitsToMinimizeStalling =
+          _audioLoadConfiguration!.darwinLoadControl!.automaticallyWaitsToMinimizeStalling;
     }
     _playbackEventSubject.add(_playbackEvent);
     _processingStateSubject.addStream(playbackEventStream
@@ -206,8 +204,7 @@ class AudioPlayer {
       if (prev.currentIndex == null || curr.currentIndex == null) return;
       if (curr.currentIndex != prev.currentIndex) {
         // If we've changed item without seeking, it must be an autoAdvance.
-        _positionDiscontinuitySubject.add(PositionDiscontinuity(
-            PositionDiscontinuityReason.autoAdvance, prev, curr));
+        _positionDiscontinuitySubject.add(PositionDiscontinuity(PositionDiscontinuityReason.autoAdvance, prev, curr));
       } else {
         // If the item is the same, try to determine whether we have looped
         // back.
@@ -218,12 +215,10 @@ class AudioPlayer {
         if (currPos >= const Duration(milliseconds: 300)) return;
         final duration = this.duration;
         if (duration != null && prevPos < duration * 0.6) return;
-        if (duration == null &&
-            currPos - prevPos < const Duration(seconds: 1)) {
+        if (duration == null && currPos - prevPos < const Duration(seconds: 1)) {
           return;
         }
-        _positionDiscontinuitySubject.add(PositionDiscontinuity(
-            PositionDiscontinuityReason.autoAdvance, prev, curr));
+        _positionDiscontinuitySubject.add(PositionDiscontinuity(PositionDiscontinuityReason.autoAdvance, prev, curr));
       }
     }, onError: (Object e, StackTrace st) {});
     _currentIndexSubject.addStream(playbackEventStream
@@ -234,8 +229,8 @@ class AudioPlayer {
         .map((event) => event.androidAudioSessionId)
         .distinct()
         .handleError((Object err, StackTrace stackTrace) {/* noop */}));
-    _sequenceStateSubject.addStream(Rx.combineLatest5<List<IndexedAudioSource>?,
-        List<int>?, int?, bool, LoopMode, SequenceState?>(
+    _sequenceStateSubject
+        .addStream(Rx.combineLatest5<List<IndexedAudioSource>?, List<int>?, int?, bool, LoopMode, SequenceState?>(
       sequenceStream,
       shuffleIndicesStream,
       currentIndexStream,
@@ -255,17 +250,13 @@ class AudioPlayer {
         );
       },
     ).distinct().handleError((Object err, StackTrace stackTrace) {/* noop */}));
-    _playerStateSubject.addStream(
-        Rx.combineLatest2<bool, PlaybackEvent, PlayerState>(
-                playingStream,
-                playbackEventStream,
-                (playing, event) => PlayerState(playing, event.processingState))
-            .distinct()
-            .handleError((Object err, StackTrace stackTrace) {/* noop */}));
+    _playerStateSubject.addStream(Rx.combineLatest2<bool, PlaybackEvent, PlayerState>(
+            playingStream, playbackEventStream, (playing, event) => PlayerState(playing, event.processingState))
+        .distinct()
+        .handleError((Object err, StackTrace stackTrace) {/* noop */}));
     _shuffleModeEnabledSubject.add(false);
     _loopModeSubject.add(LoopMode.off);
-    _setPlatformActive(false, force: true)
-        ?.catchError((dynamic e) async => null);
+    _setPlatformActive(false, force: true)?.catchError((dynamic e) async => null);
     _sequenceSubject.add(null);
     // Respond to changes to AndroidAudioAttributes configuration.
     if (androidApplyAudioAttributes && _isAndroid()) {
@@ -288,8 +279,7 @@ class AudioPlayer {
             switch (event.type) {
               case AudioInterruptionType.duck:
                 assert(_isAndroid());
-                if (session.androidAudioAttributes!.usage ==
-                    AndroidAudioUsage.game) {
+                if (session.androidAudioAttributes!.usage == AndroidAudioUsage.game) {
                   setVolume(volume / 2);
                 }
                 _playInterrupted = false;
@@ -334,8 +324,7 @@ class AudioPlayer {
   Future<void> _removeOldAssetCacheDir() async {
     if (kIsWeb) return;
     try {
-      final oldAssetCacheDir = Directory(p.join(
-          (await getTemporaryDirectory()).path, 'just_audio_asset_cache'));
+      final oldAssetCacheDir = Directory(p.join((await getTemporaryDirectory()).path, 'just_audio_asset_cache'));
       if (oldAssetCacheDir.existsSync()) {
         try {
           oldAssetCacheDir.deleteSync(recursive: true);
@@ -371,8 +360,7 @@ class AudioPlayer {
   ProcessingState get processingState => _playbackEvent.processingState;
 
   /// A stream of [ProcessingState]s.
-  Stream<ProcessingState> get processingStateStream =>
-      _processingStateSubject.stream;
+  Stream<ProcessingState> get processingStateStream => _processingStateSubject.stream;
 
   /// Whether the player is playing.
   bool get playing => _playingSubject.nvalue!;
@@ -402,16 +390,13 @@ class AudioPlayer {
   bool get skipSilenceEnabled => _skipSilenceEnabledSubject.nvalue!;
 
   /// A stream of current skipSilenceEnabled factor values.
-  Stream<bool> get skipSilenceEnabledStream =>
-      _skipSilenceEnabledSubject.stream;
+  Stream<bool> get skipSilenceEnabledStream => _skipSilenceEnabledSubject.stream;
 
   /// The position up to which buffered audio is available.
-  Duration get bufferedPosition =>
-      _bufferedPositionSubject.nvalue ?? Duration.zero;
+  Duration get bufferedPosition => _bufferedPositionSubject.nvalue ?? Duration.zero;
 
   /// A stream of buffered positions.
-  Stream<Duration> get bufferedPositionStream =>
-      _bufferedPositionSubject.stream;
+  Stream<Duration> get bufferedPositionStream => _bufferedPositionSubject.stream;
 
   /// The latest ICY metadata received through the audio source, or `null` if no
   /// metadata is available.
@@ -422,8 +407,7 @@ class AudioPlayer {
 
   /// The current player state containing only the processing and playing
   /// states.
-  PlayerState get playerState =>
-      _playerStateSubject.nvalue ?? PlayerState(false, ProcessingState.idle);
+  PlayerState get playerState => _playerStateSubject.nvalue ?? PlayerState(false, ProcessingState.idle);
 
   /// A stream of [PlayerState]s.
   Stream<PlayerState> get playerStateStream => _playerStateSubject.stream;
@@ -433,8 +417,7 @@ class AudioPlayer {
   List<IndexedAudioSource>? get sequence => _sequenceSubject.nvalue;
 
   /// A stream broadcasting the current sequence of indexed audio sources.
-  Stream<List<IndexedAudioSource>?> get sequenceStream =>
-      _sequenceSubject.stream;
+  Stream<List<IndexedAudioSource>?> get sequenceStream => _sequenceSubject.stream;
 
   /// The current shuffled sequence of indexed audio sources, or `null` if no
   /// audio source is set.
@@ -459,8 +442,7 @@ class AudioPlayer {
   SequenceState? get sequenceState => _sequenceStateSubject.nvalue;
 
   /// A stream broadcasting the current [SequenceState].
-  Stream<SequenceState?> get sequenceStateStream =>
-      _sequenceStateSubject.stream;
+  Stream<SequenceState?> get sequenceStateStream => _sequenceStateSubject.stream;
 
   /// Whether there is another item after the current index.
   bool get hasNext => nextIndex != null;
@@ -473,16 +455,12 @@ class AudioPlayer {
   /// returns `null`.
   List<int>? get effectiveIndices {
     if (shuffleIndices == null || sequence == null) return null;
-    return shuffleModeEnabled
-        ? shuffleIndices
-        : List.generate(sequence!.length, (i) => i);
+    return shuffleModeEnabled ? shuffleIndices : List.generate(sequence!.length, (i) => i);
   }
 
   List<int>? get _effectiveIndicesInv {
     if (shuffleIndices == null || sequence == null) return null;
-    return shuffleModeEnabled
-        ? _shuffleIndicesInv
-        : List.generate(sequence!.length, (i) => i);
+    return shuffleModeEnabled ? _shuffleIndicesInv : List.generate(sequence!.length, (i) => i);
   }
 
   /// The index of the next item to be played, or `null` if there is no next
@@ -523,29 +501,24 @@ class AudioPlayer {
   bool get shuffleModeEnabled => _shuffleModeEnabledSubject.nvalue!;
 
   /// A stream of the shuffle mode status.
-  Stream<bool> get shuffleModeEnabledStream =>
-      _shuffleModeEnabledSubject.stream;
+  Stream<bool> get shuffleModeEnabledStream => _shuffleModeEnabledSubject.stream;
 
   /// The current Android AudioSession ID or `null` if not set.
   int? get androidAudioSessionId => _playbackEvent.androidAudioSessionId;
 
   /// Broadcasts the current Android AudioSession ID or `null` if not set.
-  Stream<int?> get androidAudioSessionIdStream =>
-      _androidAudioSessionIdSubject.stream;
+  Stream<int?> get androidAudioSessionIdStream => _androidAudioSessionIdSubject.stream;
 
   /// A stream broadcasting every position discontinuity.
-  Stream<PositionDiscontinuity> get positionDiscontinuityStream =>
-      _positionDiscontinuitySubject.stream;
+  Stream<PositionDiscontinuity> get positionDiscontinuityStream => _positionDiscontinuitySubject.stream;
 
   /// Whether the player should automatically delay playback in order to
   /// minimize stalling. (iOS 10.0 or later only)
-  bool get automaticallyWaitsToMinimizeStalling =>
-      _automaticallyWaitsToMinimizeStalling;
+  bool get automaticallyWaitsToMinimizeStalling => _automaticallyWaitsToMinimizeStalling;
 
   /// Whether the player can use the network for live streaming while paused on
   /// iOS/macOS.
-  bool get canUseNetworkResourcesForLiveStreamingWhilePaused =>
-      _canUseNetworkResourcesForLiveStreamingWhilePaused;
+  bool get canUseNetworkResourcesForLiveStreamingWhilePaused => _canUseNetworkResourcesForLiveStreamingWhilePaused;
 
   /// The preferred peak bit rate (in bits per second) of bandwidth usage on iOS/macOS.
   double get preferredPeakBitRate => _preferredPeakBitRate;
@@ -555,11 +528,8 @@ class AudioPlayer {
 
   Duration _getPositionFor(PlaybackEvent playbackEvent) {
     if (playing && processingState == ProcessingState.ready) {
-      final result = playbackEvent.updatePosition +
-          (DateTime.now().difference(playbackEvent.updateTime)) * speed;
-      return playbackEvent.duration == null || result <= playbackEvent.duration!
-          ? result
-          : playbackEvent.duration!;
+      final result = playbackEvent.updatePosition + (DateTime.now().difference(playbackEvent.updateTime)) * speed;
+      return playbackEvent.duration == null || result <= playbackEvent.duration! ? result : playbackEvent.duration!;
     } else {
       return playbackEvent.updatePosition;
     }
@@ -578,9 +548,7 @@ class AudioPlayer {
       _positionSubject = BehaviorSubject<Duration>();
       if (!_disposed) {
         _positionSubject!.addStream(createPositionStream(
-            steps: 800,
-            minPeriod: const Duration(milliseconds: 16),
-            maxPeriod: const Duration(milliseconds: 200)));
+            steps: 800, minPeriod: const Duration(milliseconds: 16), maxPeriod: const Duration(milliseconds: 200)));
       }
     }
     return _positionSubject!.stream;
@@ -685,8 +653,7 @@ class AudioPlayer {
     Duration? initialPosition,
     bool preload = true,
   }) =>
-      setAudioSource(AudioSource.file(filePath),
-          initialPosition: initialPosition, preload: preload);
+      setAudioSource(AudioSource.file(filePath), initialPosition: initialPosition, preload: preload);
 
   /// Convenience method to set the audio source to an asset, preloaded by
   /// default, with an initial position of zero by default.
@@ -743,11 +710,9 @@ class AudioPlayer {
   }) async {
     if (_disposed) return null;
     _audioSource = null;
-    _initialSeekValues =
-        _InitialSeekValues(position: initialPosition, index: initialIndex);
-    _playbackEventSubject.add(_playbackEvent = PlaybackEvent(
-        currentIndex: initialIndex ?? 0,
-        updatePosition: initialPosition ?? Duration.zero));
+    _initialSeekValues = _InitialSeekValues(position: initialPosition, index: initialIndex);
+    _playbackEventSubject.add(_playbackEvent =
+        PlaybackEvent(currentIndex: initialIndex ?? 0, updatePosition: initialPosition ?? Duration.zero));
     _audioSource = source;
     _broadcastSequence();
     Duration? duration;
@@ -778,8 +743,7 @@ class AudioPlayer {
     if (_active) {
       final initialSeekValues = _initialSeekValues;
       _initialSeekValues = null;
-      return await _load(await _platform, _audioSource!,
-          initialSeekValues: initialSeekValues);
+      return await _load(await _platform, _audioSource!, initialSeekValues: initialSeekValues);
     } else {
       // This will implicitly load the current audio source.
       return await _setPlatformActive(true);
@@ -797,11 +761,9 @@ class AudioPlayer {
     _shuffleIndicesSubject.add(_audioSource?.shuffleIndices);
     final shuffleIndicesLength = shuffleIndices?.length ?? 0;
     if (_shuffleIndicesInv.length > shuffleIndicesLength) {
-      _shuffleIndicesInv.removeRange(
-          shuffleIndicesLength, _shuffleIndicesInv.length);
+      _shuffleIndicesInv.removeRange(shuffleIndicesLength, _shuffleIndicesInv.length);
     } else if (_shuffleIndicesInv.length < shuffleIndicesLength) {
-      _shuffleIndicesInv.addAll(
-          List.filled(shuffleIndicesLength - _shuffleIndicesInv.length, 0));
+      _shuffleIndicesInv.addAll(List.filled(shuffleIndicesLength - _shuffleIndicesInv.length, 0));
     }
     for (var i = 0; i < shuffleIndicesLength; i++) {
       _shuffleIndicesInv[shuffleIndices![i]] = i;
@@ -842,8 +804,7 @@ class AudioPlayer {
         throw PlatformException(code: 'abort', message: 'Loading interrupted');
       }
       // Wait for loading state to pass.
-      await processingStateStream
-          .firstWhere((state) => state != ProcessingState.loading);
+      await processingStateStream.firstWhere((state) => state != ProcessingState.loading);
       checkInterruption();
       return duration;
     } on PlatformException catch (e) {
@@ -926,8 +887,7 @@ class AudioPlayer {
         } else {
           // If the native platform wasn't already active, activating it will
           // implicitly restore the playing state and send a play request.
-          _setPlatformActive(true, playCompleter: playCompleter)
-              ?.catchError((dynamic e) async => null);
+          _setPlatformActive(true, playCompleter: playCompleter)?.catchError((dynamic e) async => null);
         }
       }
     } else {
@@ -956,8 +916,7 @@ class AudioPlayer {
     await (await _platform).pause(PauseRequest());
   }
 
-  Future<void> _sendPlayRequest(
-      AudioPlayerPlatform platform, Completer<void>? playCompleter) async {
+  Future<void> _sendPlayRequest(AudioPlayerPlatform platform, Completer<void>? playCompleter) async {
     try {
       if (!playing) return; // defensive
       await platform.play(PlayRequest());
@@ -977,8 +936,7 @@ class AudioPlayer {
   /// decoders alive so that the app can quickly resume audio playback.
   Future<void> stop() async {
     if (_disposed) return;
-    final future =
-        _setPlatformActive(false)?.catchError((dynamic e) async => null);
+    final future = _setPlatformActive(false)?.catchError((dynamic e) async => null);
 
     _playInterrupted = false;
     // Update local state immediately so that queries aren't surprised.
@@ -1001,8 +959,7 @@ class AudioPlayer {
     if (enabled == previouslyEnabled) return;
     _skipSilenceEnabledSubject.add(enabled);
     try {
-      await (await _platform)
-          .setSkipSilence(SetSkipSilenceRequest(enabled: enabled));
+      await (await _platform).setSkipSilence(SetSkipSilenceRequest(enabled: enabled));
     } catch (e) {
       _skipSilenceEnabledSubject.add(previouslyEnabled);
       rethrow;
@@ -1041,17 +998,15 @@ class AudioPlayer {
   Future<void> setLoopMode(LoopMode mode) async {
     if (_disposed) return;
     _loopModeSubject.add(mode);
-    await (await _platform).setLoopMode(
-        SetLoopModeRequest(loopMode: LoopModeMessage.values[mode.index]));
+    await (await _platform).setLoopMode(SetLoopModeRequest(loopMode: LoopModeMessage.values[mode.index]));
   }
 
   /// Sets whether shuffle mode is enabled.
   Future<void> setShuffleModeEnabled(bool enabled) async {
     if (_disposed) return;
     _shuffleModeEnabledSubject.add(enabled);
-    await (await _platform).setShuffleMode(SetShuffleModeRequest(
-        shuffleMode:
-            enabled ? ShuffleModeMessage.all : ShuffleModeMessage.none));
+    await (await _platform)
+        .setShuffleMode(SetShuffleModeRequest(shuffleMode: enabled ? ShuffleModeMessage.all : ShuffleModeMessage.none));
   }
 
   /// Recursively shuffles the children of the currently loaded [AudioSource].
@@ -1062,20 +1017,16 @@ class AudioPlayer {
     if (_audioSource == null) return;
     _audioSource!._shuffle(initialIndex: currentIndex);
     _updateShuffleIndices();
-    await (await _platform).setShuffleOrder(
-        SetShuffleOrderRequest(audioSourceMessage: _audioSource!._toMessage()));
+    await (await _platform).setShuffleOrder(SetShuffleOrderRequest(audioSourceMessage: _audioSource!._toMessage()));
   }
 
   /// Sets automaticallyWaitsToMinimizeStalling for AVPlayer in iOS 10.0 or later, defaults to true.
   /// Has no effect on Android clients
-  Future<void> setAutomaticallyWaitsToMinimizeStalling(
-      final bool automaticallyWaitsToMinimizeStalling) async {
+  Future<void> setAutomaticallyWaitsToMinimizeStalling(final bool automaticallyWaitsToMinimizeStalling) async {
     if (_disposed) return;
-    _automaticallyWaitsToMinimizeStalling =
-        automaticallyWaitsToMinimizeStalling;
+    _automaticallyWaitsToMinimizeStalling = automaticallyWaitsToMinimizeStalling;
     await (await _platform).setAutomaticallyWaitsToMinimizeStalling(
-        SetAutomaticallyWaitsToMinimizeStallingRequest(
-            enabled: automaticallyWaitsToMinimizeStalling));
+        SetAutomaticallyWaitsToMinimizeStallingRequest(enabled: automaticallyWaitsToMinimizeStalling));
   }
 
   /// Sets canUseNetworkResourcesForLiveStreamingWhilePaused on iOS/macOS,
@@ -1083,21 +1034,17 @@ class AudioPlayer {
   Future<void> setCanUseNetworkResourcesForLiveStreamingWhilePaused(
       final bool canUseNetworkResourcesForLiveStreamingWhilePaused) async {
     if (_disposed) return;
-    _canUseNetworkResourcesForLiveStreamingWhilePaused =
-        canUseNetworkResourcesForLiveStreamingWhilePaused;
-    await (await _platform)
-        .setCanUseNetworkResourcesForLiveStreamingWhilePaused(
-            SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest(
-                enabled: canUseNetworkResourcesForLiveStreamingWhilePaused));
+    _canUseNetworkResourcesForLiveStreamingWhilePaused = canUseNetworkResourcesForLiveStreamingWhilePaused;
+    await (await _platform).setCanUseNetworkResourcesForLiveStreamingWhilePaused(
+        SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest(
+            enabled: canUseNetworkResourcesForLiveStreamingWhilePaused));
   }
 
   /// Sets preferredPeakBitRate on iOS/macOS, defaults to true.
-  Future<void> setPreferredPeakBitRate(
-      final double preferredPeakBitRate) async {
+  Future<void> setPreferredPeakBitRate(final double preferredPeakBitRate) async {
     if (_disposed) return;
     _preferredPeakBitRate = preferredPeakBitRate;
-    await (await _platform).setPreferredPeakBitRate(
-        SetPreferredPeakBitRateRequest(bitRate: preferredPeakBitRate));
+    await (await _platform).setPreferredPeakBitRate(SetPreferredPeakBitRateRequest(bitRate: preferredPeakBitRate));
   }
 
   /// Seeks to a particular [position]. If a composition of multiple
@@ -1121,12 +1068,9 @@ class AudioPlayer {
             updateTime: DateTime.now(),
           );
           _playbackEventSubject.add(_playbackEvent);
-          _positionDiscontinuitySubject.add(PositionDiscontinuity(
-              PositionDiscontinuityReason.seek,
-              prevPlaybackEvent,
-              _playbackEvent));
-          await (await _platform)
-              .seek(SeekRequest(position: position, index: index));
+          _positionDiscontinuitySubject
+              .add(PositionDiscontinuity(PositionDiscontinuityReason.seek, prevPlaybackEvent, _playbackEvent));
+          await (await _platform).seek(SeekRequest(position: position, index: index));
         } finally {
           _seeking = false;
         }
@@ -1149,8 +1093,7 @@ class AudioPlayer {
 
   /// Set the Android audio attributes for this player. Has no effect on other
   /// platforms. This will cause a new Android AudioSession ID to be generated.
-  Future<void> setAndroidAudioAttributes(
-      AndroidAudioAttributes audioAttributes) async {
+  Future<void> setAndroidAudioAttributes(AndroidAudioAttributes audioAttributes) async {
     if (_disposed) return;
     if (!_isAndroid() && !_isUnitTest()) return;
     if (audioAttributes == _androidAudioAttributes) return;
@@ -1158,8 +1101,8 @@ class AudioPlayer {
     await _internalSetAndroidAudioAttributes(await _platform, audioAttributes);
   }
 
-  Future<void> _internalSetAndroidAudioAttributes(AudioPlayerPlatform platform,
-      AndroidAudioAttributes audioAttributes) async {
+  Future<void> _internalSetAndroidAudioAttributes(
+      AudioPlayerPlatform platform, AndroidAudioAttributes audioAttributes) async {
     if (!_isAndroid() && !_isUnitTest()) return;
     await platform.setAndroidAudioAttributes(SetAndroidAudioAttributesRequest(
         contentType: audioAttributes.contentType.index,
@@ -1204,8 +1147,7 @@ class AudioPlayer {
   ///
   /// The platform will not switch if [active] == [_active] unless [force] is
   /// `true`.
-  Future<Duration?>? _setPlatformActive(bool active,
-      {Completer<void>? playCompleter, bool force = false}) {
+  Future<Duration?>? _setPlatformActive(bool active, {Completer<void>? playCompleter, bool force = false}) {
     if (_disposed) return null;
     if (!force && (active == _active)) return _durationFuture;
     _platformLoading = active;
@@ -1241,8 +1183,7 @@ class AudioPlayer {
       // An interruption that we can ignore
       if (!active) return true;
       // An interruption that should throw
-      final e =
-          PlatformException(code: 'abort', message: 'Loading interrupted');
+      final e = PlatformException(code: 'abort', message: 'Loading interrupted');
       durationCompleter.completeError(e);
       throw e;
     }
@@ -1255,8 +1196,7 @@ class AudioPlayer {
     final audioSource = _audioSource;
 
     void subscribeToEvents(AudioPlayerPlatform platform) {
-      _playerDataSubscription =
-          platform.playerDataMessageStream.listen((message) {
+      _playerDataSubscription = platform.playerDataMessageStream.listen((message) {
         if (message.playing != null && message.playing != playing) {
           _playingSubject.add(message.playing!);
         }
@@ -1273,12 +1213,10 @@ class AudioPlayer {
           _loopModeSubject.add(LoopMode.values[message.loopMode!.index]);
         }
         if (message.shuffleMode != null) {
-          _shuffleModeEnabledSubject
-              .add(message.shuffleMode != ShuffleModeMessage.none);
+          _shuffleModeEnabledSubject.add(message.shuffleMode != ShuffleModeMessage.none);
         }
       });
-      _playbackEventSubscription =
-          platform.playbackEventMessageStream.listen((message) {
+      _playbackEventSubscription = platform.playbackEventMessageStream.listen((message) {
         var duration = message.duration;
         var index = message.currentIndex ?? currentIndex;
         if (index != null && sequence != null && index < sequence!.length) {
@@ -1288,23 +1226,19 @@ class AudioPlayer {
             sequence![index].duration = duration;
           }
         }
-        if (_platformLoading &&
-            message.processingState != ProcessingStateMessage.idle) {
+        if (_platformLoading && message.processingState != ProcessingStateMessage.idle) {
           _platformLoading = false;
         }
         final playbackEvent = PlaybackEvent(
           // The platform may emit an idle state while it's starting up which we
           // override here.
-          processingState: _platformLoading
-              ? ProcessingState.loading
-              : ProcessingState.values[message.processingState.index],
+          processingState:
+              _platformLoading ? ProcessingState.loading : ProcessingState.values[message.processingState.index],
           updateTime: message.updateTime,
           updatePosition: message.updatePosition,
           bufferedPosition: message.bufferedPosition,
           duration: duration,
-          icyMetadata: message.icyMetadata == null
-              ? null
-              : IcyMetadata._fromMessage(message.icyMetadata!),
+          icyMetadata: message.icyMetadata == null ? null : IcyMetadata._fromMessage(message.icyMetadata!),
           currentIndex: index,
           androidAudioSessionId: message.androidAudioSessionId,
         );
@@ -1317,8 +1251,7 @@ class AudioPlayer {
         }
         final oldPlaybackEvent = _playbackEvent;
         _playbackEventSubject.add(_playbackEvent = playbackEvent);
-        if (_playbackEvent.processingState !=
-                oldPlaybackEvent.processingState &&
+        if (_playbackEvent.processingState != oldPlaybackEvent.processingState &&
             _playbackEvent.processingState == ProcessingState.idle) {
           _setPlatformActive(false)?.catchError((dynamic e) async => null);
         }
@@ -1342,19 +1275,14 @@ class AudioPlayer {
               id: _id,
               audioLoadConfiguration: _audioLoadConfiguration?._toMessage(),
               androidAudioEffects: (_isAndroid() || _isUnitTest())
-                  ? _audioPipeline.androidAudioEffects
-                      .map((audioEffect) => audioEffect._toMessage())
-                      .toList()
+                  ? _audioPipeline.androidAudioEffects.map((audioEffect) => audioEffect._toMessage()).toList()
                   : [],
               darwinAudioEffects: (_isDarwin() || _isUnitTest())
-                  ? _audioPipeline.darwinAudioEffects
-                      .map((audioEffect) => audioEffect._toMessage())
-                      .toList()
+                  ? _audioPipeline.darwinAudioEffects.map((audioEffect) => audioEffect._toMessage()).toList()
                   : [],
               androidOffloadSchedulingEnabled: _androidOffloadSchedulingEnabled,
             )))
-          : (_idlePlatform =
-              _IdleAudioPlayer(id: _id, sequenceStream: sequenceStream));
+          : (_idlePlatform = _IdleAudioPlayer(id: _id, sequenceStream: sequenceStream));
       if (checkInterruption()) return platform;
 
       _platformValue = platform;
@@ -1367,8 +1295,7 @@ class AudioPlayer {
           ));
         }
 
-        final automaticallyWaitsToMinimizeStalling =
-            this.automaticallyWaitsToMinimizeStalling;
+        final automaticallyWaitsToMinimizeStalling = this.automaticallyWaitsToMinimizeStalling;
         final playing = this.playing;
         // To avoid a glitch in ExoPlayer, ensure that any requested audio
         // attributes are set before loading the audio source.
@@ -1376,20 +1303,17 @@ class AudioPlayer {
           if (_androidApplyAudioAttributes) {
             final audioSession = await AudioSession.instance;
             if (checkInterruption()) return platform;
-            _androidAudioAttributes ??=
-                audioSession.configuration?.androidAudioAttributes;
+            _androidAudioAttributes ??= audioSession.configuration?.androidAudioAttributes;
           }
           if (_androidAudioAttributes != null) {
-            await _internalSetAndroidAudioAttributes(
-                platform, _androidAudioAttributes!);
+            await _internalSetAndroidAudioAttributes(platform, _androidAudioAttributes!);
             if (checkInterruption()) return platform;
           }
         }
         if (!automaticallyWaitsToMinimizeStalling) {
           // Only set if different from default.
           await platform.setAutomaticallyWaitsToMinimizeStalling(
-              SetAutomaticallyWaitsToMinimizeStallingRequest(
-                  enabled: automaticallyWaitsToMinimizeStalling));
+              SetAutomaticallyWaitsToMinimizeStallingRequest(enabled: automaticallyWaitsToMinimizeStalling));
           if (checkInterruption()) return platform;
         }
         await platform.setVolume(SetVolumeRequest(volume: volume));
@@ -1403,19 +1327,15 @@ class AudioPlayer {
         }
         if (checkInterruption()) return platform;
         try {
-          await platform.setSkipSilence(
-              SetSkipSilenceRequest(enabled: skipSilenceEnabled));
+          await platform.setSkipSilence(SetSkipSilenceRequest(enabled: skipSilenceEnabled));
         } catch (e) {
           // setSkipSilence not supported on this platform.
         }
         if (checkInterruption()) return platform;
-        await platform.setLoopMode(SetLoopModeRequest(
-            loopMode: LoopModeMessage.values[loopMode.index]));
+        await platform.setLoopMode(SetLoopModeRequest(loopMode: LoopModeMessage.values[loopMode.index]));
         if (checkInterruption()) return platform;
-        await platform.setShuffleMode(SetShuffleModeRequest(
-            shuffleMode: shuffleModeEnabled
-                ? ShuffleModeMessage.all
-                : ShuffleModeMessage.none));
+        await platform.setShuffleMode(
+            SetShuffleModeRequest(shuffleMode: shuffleModeEnabled ? ShuffleModeMessage.all : ShuffleModeMessage.none));
         if (checkInterruption()) return platform;
         for (var audioEffect in _audioPipeline._audioEffects) {
           await audioEffect._activate(platform);
@@ -1430,16 +1350,13 @@ class AudioPlayer {
 
       if (audioSource != null) {
         try {
-          final initialSeekValues = _initialSeekValues ??
-              _InitialSeekValues(position: position, index: currentIndex);
+          final initialSeekValues = _initialSeekValues ?? _InitialSeekValues(position: position, index: currentIndex);
           _initialSeekValues = null;
-          final duration = await _load(platform, _audioSource!,
-              initialSeekValues: initialSeekValues);
+          final duration = await _load(platform, _audioSource!, initialSeekValues: initialSeekValues);
           if (checkInterruption()) return platform;
           durationCompleter.complete(duration);
         } catch (e, stackTrace) {
-          await _setPlatformActive(false)
-              ?.catchError((dynamic e) async => null);
+          await _setPlatformActive(false)?.catchError((dynamic e) async => null);
           durationCompleter.completeError(e, stackTrace);
         }
       } else {
@@ -1566,8 +1483,7 @@ class PlaybackEvent {
         duration: duration ?? this.duration,
         icyMetadata: icyMetadata ?? this.icyMetadata,
         currentIndex: currentIndex ?? this.currentIndex,
-        androidAudioSessionId:
-            androidAudioSessionId ?? this.androidAudioSessionId,
+        androidAudioSessionId: androidAudioSessionId ?? this.androidAudioSessionId,
       );
 
   @override
@@ -1665,10 +1581,7 @@ class IcyInfo {
 
   @override
   bool operator ==(Object other) =>
-      other.runtimeType == runtimeType &&
-      other is IcyInfo &&
-      other.title == title &&
-      other.url == url;
+      other.runtimeType == runtimeType && other is IcyInfo && other.title == title && other.url == url;
 }
 
 class IcyHeaders {
@@ -1722,9 +1635,7 @@ class IcyMetadata {
 
   static IcyMetadata _fromMessage(IcyMetadataMessage message) => IcyMetadata(
         info: message.info == null ? null : IcyInfo._fromMessage(message.info!),
-        headers: message.headers == null
-            ? null
-            : IcyHeaders._fromMessage(message.headers!),
+        headers: message.headers == null ? null : IcyHeaders._fromMessage(message.headers!),
       );
 
   IcyMetadata({required this.info, required this.headers});
@@ -1734,10 +1645,7 @@ class IcyMetadata {
 
   @override
   bool operator ==(Object other) =>
-      other.runtimeType == runtimeType &&
-      other is IcyMetadata &&
-      other.info == info &&
-      other.headers == headers;
+      other.runtimeType == runtimeType && other is IcyMetadata && other.info == info && other.headers == headers;
 }
 
 /// Encapsulates the [sequence] and [currentIndex] state and ensures
@@ -1760,18 +1668,15 @@ class SequenceState {
   /// The current loop mode.
   final LoopMode loopMode;
 
-  SequenceState(this.sequence, this.currentIndex, this.shuffleIndices,
-      this.shuffleModeEnabled, this.loopMode);
+  SequenceState(this.sequence, this.currentIndex, this.shuffleIndices, this.shuffleModeEnabled, this.loopMode);
 
   /// The current source in the sequence.
-  IndexedAudioSource? get currentSource =>
-      sequence.isEmpty ? null : sequence[currentIndex];
+  IndexedAudioSource? get currentSource => sequence.isEmpty ? null : sequence[currentIndex];
 
   /// The effective sequence. This is equivalent to [sequence]. If
   /// [shuffleModeEnabled] is true, this is modulated by [shuffleIndices].
-  List<IndexedAudioSource> get effectiveSequence => shuffleModeEnabled
-      ? shuffleIndices.map((i) => sequence[i]).toList()
-      : sequence;
+  List<IndexedAudioSource> get effectiveSequence =>
+      shuffleModeEnabled ? shuffleIndices.map((i) => sequence[i]).toList() : sequence;
 }
 
 /// Configuration options to use when loading audio from a source.
@@ -1794,8 +1699,7 @@ class AudioLoadConfiguration {
   AudioLoadConfigurationMessage _toMessage() => AudioLoadConfigurationMessage(
         darwinLoadControl: darwinLoadControl?._toMessage(),
         androidLoadControl: androidLoadControl?._toMessage(),
-        androidLivePlaybackSpeedControl:
-            androidLivePlaybackSpeedControl?._toMessage(),
+        androidLivePlaybackSpeedControl: androidLivePlaybackSpeedControl?._toMessage(),
       );
 }
 
@@ -1826,11 +1730,9 @@ class DarwinLoadControl {
   });
 
   DarwinLoadControlMessage _toMessage() => DarwinLoadControlMessage(
-        automaticallyWaitsToMinimizeStalling:
-            automaticallyWaitsToMinimizeStalling,
+        automaticallyWaitsToMinimizeStalling: automaticallyWaitsToMinimizeStalling,
         preferredForwardBufferDuration: preferredForwardBufferDuration,
-        canUseNetworkResourcesForLiveStreamingWhilePaused:
-            canUseNetworkResourcesForLiveStreamingWhilePaused,
+        canUseNetworkResourcesForLiveStreamingWhilePaused: canUseNetworkResourcesForLiveStreamingWhilePaused,
         preferredPeakBitRate: preferredPeakBitRate,
       );
 }
@@ -1877,8 +1779,7 @@ class AndroidLoadControl {
         minBufferDuration: minBufferDuration,
         maxBufferDuration: maxBufferDuration,
         bufferForPlaybackDuration: bufferForPlaybackDuration,
-        bufferForPlaybackAfterRebufferDuration:
-            bufferForPlaybackAfterRebufferDuration,
+        bufferForPlaybackAfterRebufferDuration: bufferForPlaybackAfterRebufferDuration,
         targetBufferBytes: targetBufferBytes,
         prioritizeTimeOverSizeThresholds: prioritizeTimeOverSizeThresholds,
         backBufferDuration: backBufferDuration,
@@ -1922,22 +1823,18 @@ class AndroidLivePlaybackSpeedControl {
     this.minUpdateInterval = const Duration(seconds: 1),
     this.proportionalControlFactor = 1.0,
     this.maxLiveOffsetErrorForUnitSpeed = const Duration(milliseconds: 20),
-    this.targetLiveOffsetIncrementOnRebuffer =
-        const Duration(milliseconds: 500),
+    this.targetLiveOffsetIncrementOnRebuffer = const Duration(milliseconds: 500),
     this.minPossibleLiveOffsetSmoothingFactor = 0.999,
   });
 
-  AndroidLivePlaybackSpeedControlMessage _toMessage() =>
-      AndroidLivePlaybackSpeedControlMessage(
+  AndroidLivePlaybackSpeedControlMessage _toMessage() => AndroidLivePlaybackSpeedControlMessage(
         fallbackMinPlaybackSpeed: fallbackMinPlaybackSpeed,
         fallbackMaxPlaybackSpeed: fallbackMaxPlaybackSpeed,
         minUpdateInterval: minUpdateInterval,
         proportionalControlFactor: proportionalControlFactor,
         maxLiveOffsetErrorForUnitSpeed: maxLiveOffsetErrorForUnitSpeed,
-        targetLiveOffsetIncrementOnRebuffer:
-            targetLiveOffsetIncrementOnRebuffer,
-        minPossibleLiveOffsetSmoothingFactor:
-            minPossibleLiveOffsetSmoothingFactor,
+        targetLiveOffsetIncrementOnRebuffer: targetLiveOffsetIncrementOnRebuffer,
+        minPossibleLiveOffsetSmoothingFactor: minPossibleLiveOffsetSmoothingFactor,
       );
 }
 
@@ -1983,8 +1880,8 @@ class _ProxyHttpServer {
     return uri;
   }
 
-  Uri _sourceUri(StreamAudioSource source) => Uri.http(
-      '${InternetAddress.loopbackIPv4.address}:$port', '/id/${source._id}');
+  Uri _sourceUri(StreamAudioSource source) =>
+      Uri.http('${InternetAddress.loopbackIPv4.address}:$port', '/id/${source._id}');
 
   /// A unique key for each request that can be processed by this proxy,
   /// made up of the URL path and query string. It is not possible to
@@ -2038,8 +1935,7 @@ class _HttpRangeRequest {
   _HttpRangeRequest(this.start, this.end);
 
   /// Format a range header for this request.
-  String get header =>
-      'bytes=$start-${end != null ? (end! - 1).toString() : ""}';
+  String get header => 'bytes=$start-${end != null ? (end! - 1).toString() : ""}';
 
   /// Creates an [_HttpRangeRequest] from [header].
   static _HttpRangeRequest? parse(List<String>? header) {
@@ -2094,11 +1990,9 @@ abstract class AudioSource {
   ///
   /// If headers are set, just_audio will create a cleartext local HTTP proxy on
   /// your device to forward HTTP requests with headers included.
-  static UriAudioSource uri(Uri uri,
-      {Map<String, String>? headers, dynamic tag}) {
+  static UriAudioSource uri(Uri uri, {Map<String, String>? headers, dynamic tag}) {
     bool hasExtension(Uri uri, String extension) =>
-        uri.path.toLowerCase().endsWith('.$extension') ||
-        uri.fragment.toLowerCase().endsWith('.$extension');
+        uri.path.toLowerCase().endsWith('.$extension') || uri.fragment.toLowerCase().endsWith('.$extension');
     if (hasExtension(uri, 'mpd')) {
       return DashAudioSource(uri, headers: headers, tag: tag);
     } else if (hasExtension(uri, 'm3u8')) {
@@ -2129,10 +2023,8 @@ abstract class AudioSource {
   ///
   /// If the asset is to be loaded from a different package, the [package]
   /// parameter must be given to specify the package name.
-  static UriAudioSource asset(String assetPath,
-      {String? package, dynamic tag}) {
-    final keyName =
-        package == null ? assetPath : 'packages/$package/$assetPath';
+  static UriAudioSource asset(String assetPath, {String? package, dynamic tag}) {
+    final keyName = package == null ? assetPath : 'packages/$package/$assetPath';
     return AudioSource.uri(Uri.parse('asset:///$keyName'), tag: tag);
   }
 
@@ -2162,10 +2054,7 @@ abstract class AudioSource {
   int get hashCode => _id.hashCode;
 
   @override
-  bool operator ==(Object other) =>
-      other.runtimeType == runtimeType &&
-      other is AudioSource &&
-      other._id == _id;
+  bool operator ==(Object other) => other.runtimeType == runtimeType && other is AudioSource && other._id == _id;
 }
 
 /// An [AudioSource] that can appear in a sequence.
@@ -2191,8 +2080,7 @@ abstract class UriAudioSource extends IndexedAudioSource {
   final Map<String, String>? headers;
   Uri? _overrideUri;
 
-  UriAudioSource(this.uri, {this.headers, dynamic tag, Duration? duration})
-      : super(tag: tag, duration: duration);
+  UriAudioSource(this.uri, {this.headers, dynamic tag, Duration? duration}) : super(tag: tag, duration: duration);
 
   /// If [uri] points to an asset, this gives us [_overrideUri] which is the URI
   /// of the copied asset on the filesystem, otherwise it gives us the original
@@ -2204,9 +2092,7 @@ abstract class UriAudioSource extends IndexedAudioSource {
     await super._setup(player);
     if (uri.scheme == 'asset') {
       _overrideUri = await _loadAsset(uri.pathSegments.join('/'));
-    } else if (uri.scheme != 'file' &&
-        !kIsWeb &&
-        (headers != null || player._userAgent != null)) {
+    } else if (uri.scheme != 'file' && !kIsWeb && (headers != null || player._userAgent != null)) {
       await player._proxy.ensureRunning();
       _overrideUri = player._proxy.addUriAudioSource(this);
     }
@@ -2231,12 +2117,8 @@ abstract class UriAudioSource extends IndexedAudioSource {
         '.m3u': 'audio/x-mpegurl',
       };
       // Default to 'audio/mpeg'
-      final mimeType =
-          mimeTypes[p.extension(assetPath).toLowerCase()] ?? 'audio/mpeg';
-      return _encodeDataUrl(
-          base64
-              .encode((await rootBundle.load(assetPath)).buffer.asUint8List()),
-          mimeType);
+      final mimeType = mimeTypes[p.extension(assetPath).toLowerCase()] ?? 'audio/mpeg';
+      return _encodeDataUrl(base64.encode((await rootBundle.load(assetPath)).buffer.asUint8List()), mimeType);
     } else {
       // For non-web platforms, extract the asset into a cache file and pass
       // that to the player.
@@ -2245,8 +2127,7 @@ abstract class UriAudioSource extends IndexedAudioSource {
       // locking the file or creating a separate lock file.
       if (!file.existsSync()) {
         file.createSync(recursive: true);
-        await file.writeAsBytes(
-            (await rootBundle.load(assetPath)).buffer.asUint8List());
+        await file.writeAsBytes((await rootBundle.load(assetPath)).buffer.asUint8List());
       }
       return Uri.file(file.path);
     }
@@ -2274,13 +2155,12 @@ abstract class UriAudioSource extends IndexedAudioSource {
 /// If headers are set, just_audio will create a cleartext local HTTP proxy on
 /// your device to forward HTTP requests with headers included.
 class ProgressiveAudioSource extends UriAudioSource {
-  ProgressiveAudioSource(Uri uri,
-      {Map<String, String>? headers, dynamic tag, Duration? duration})
+  ProgressiveAudioSource(Uri uri, {Map<String, String>? headers, dynamic tag, Duration? duration})
       : super(uri, headers: headers, tag: tag, duration: duration);
 
   @override
-  AudioSourceMessage _toMessage() => ProgressiveAudioSourceMessage(
-      id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
+  AudioSourceMessage _toMessage() =>
+      ProgressiveAudioSourceMessage(id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
 }
 
 /// An [AudioSource] representing a DASH stream. The following URI schemes are
@@ -2298,13 +2178,12 @@ class ProgressiveAudioSource extends UriAudioSource {
 /// If headers are set, just_audio will create a cleartext local HTTP proxy on
 /// your device to forward HTTP requests with headers included.
 class DashAudioSource extends UriAudioSource {
-  DashAudioSource(Uri uri,
-      {Map<String, String>? headers, dynamic tag, Duration? duration})
+  DashAudioSource(Uri uri, {Map<String, String>? headers, dynamic tag, Duration? duration})
       : super(uri, headers: headers, tag: tag, duration: duration);
 
   @override
-  AudioSourceMessage _toMessage() => DashAudioSourceMessage(
-      id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
+  AudioSourceMessage _toMessage() =>
+      DashAudioSourceMessage(id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
 }
 
 /// An [AudioSource] representing an HLS stream. The following URI schemes are
@@ -2321,13 +2200,12 @@ class DashAudioSource extends UriAudioSource {
 /// If headers are set, just_audio will create a cleartext local HTTP proxy on
 /// your device to forward HTTP requests with headers included.
 class HlsAudioSource extends UriAudioSource {
-  HlsAudioSource(Uri uri,
-      {Map<String, String>? headers, dynamic tag, Duration? duration})
+  HlsAudioSource(Uri uri, {Map<String, String>? headers, dynamic tag, Duration? duration})
       : super(uri, headers: headers, tag: tag, duration: duration);
 
   @override
-  AudioSourceMessage _toMessage() => HlsAudioSourceMessage(
-      id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
+  AudioSourceMessage _toMessage() =>
+      HlsAudioSourceMessage(id: _id, uri: _effectiveUri.toString(), headers: headers, tag: tag);
 }
 
 /// An [AudioSource] for a period of silence.
@@ -2346,8 +2224,7 @@ class SilenceAudioSource extends IndexedAudioSource {
   }) : super(tag: tag, duration: duration);
 
   @override
-  AudioSourceMessage _toMessage() =>
-      SilenceAudioSourceMessage(id: _id, duration: duration);
+  AudioSourceMessage _toMessage() => SilenceAudioSourceMessage(id: _id, duration: duration);
 }
 
 /// An [AudioSource] representing a concatenation of multiple audio sources to
@@ -2391,14 +2268,11 @@ class ConcatenatingAudioSource extends AudioSource {
     for (var ci = 0, si = 0; ci < children.length; ci++) {
       final child = children[ci];
       final childLength = child.sequence.length;
-      final initialIndexWithinThisChild = initialIndex != null &&
-          initialIndex >= si &&
-          initialIndex < si + childLength;
+      final initialIndexWithinThisChild = initialIndex != null && initialIndex >= si && initialIndex < si + childLength;
       if (initialIndexWithinThisChild) {
         localInitialIndex = ci;
       }
-      final childInitialIndex =
-          initialIndexWithinThisChild ? (initialIndex! - si) : null;
+      final childInitialIndex = initialIndexWithinThisChild ? (initialIndex! - si) : null;
       child._shuffle(initialIndex: childInitialIndex);
       si += childLength;
     }
@@ -2413,12 +2287,8 @@ class ConcatenatingAudioSource extends AudioSource {
     if (_player != null) {
       _player!._broadcastSequence();
       await audioSource._setup(_player!);
-      await (await _player!._platform).concatenatingInsertAll(
-          ConcatenatingInsertAllRequest(
-              id: _id,
-              index: index,
-              children: [audioSource._toMessage()],
-              shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingInsertAll(ConcatenatingInsertAllRequest(
+          id: _id, index: index, children: [audioSource._toMessage()], shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2429,12 +2299,8 @@ class ConcatenatingAudioSource extends AudioSource {
     if (_player != null) {
       _player!._broadcastSequence();
       await audioSource._setup(_player!);
-      await (await _player!._platform).concatenatingInsertAll(
-          ConcatenatingInsertAllRequest(
-              id: _id,
-              index: index,
-              children: [audioSource._toMessage()],
-              shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingInsertAll(ConcatenatingInsertAllRequest(
+          id: _id, index: index, children: [audioSource._toMessage()], shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2448,12 +2314,11 @@ class ConcatenatingAudioSource extends AudioSource {
       for (var child in children) {
         await child._setup(_player!);
       }
-      await (await _player!._platform).concatenatingInsertAll(
-          ConcatenatingInsertAllRequest(
-              id: _id,
-              index: index,
-              children: children.map((child) => child._toMessage()).toList(),
-              shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingInsertAll(ConcatenatingInsertAllRequest(
+          id: _id,
+          index: index,
+          children: children.map((child) => child._toMessage()).toList(),
+          shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2466,12 +2331,11 @@ class ConcatenatingAudioSource extends AudioSource {
       for (var child in children) {
         await child._setup(_player!);
       }
-      await (await _player!._platform).concatenatingInsertAll(
-          ConcatenatingInsertAllRequest(
-              id: _id,
-              index: index,
-              children: children.map((child) => child._toMessage()).toList(),
-              shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingInsertAll(ConcatenatingInsertAllRequest(
+          id: _id,
+          index: index,
+          children: children.map((child) => child._toMessage()).toList(),
+          shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2482,12 +2346,8 @@ class ConcatenatingAudioSource extends AudioSource {
     _shuffleOrder.removeRange(index, index + 1);
     if (_player != null) {
       _player!._broadcastSequence();
-      await (await _player!._platform).concatenatingRemoveRange(
-          ConcatenatingRemoveRangeRequest(
-              id: _id,
-              startIndex: index,
-              endIndex: index + 1,
-              shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingRemoveRange(ConcatenatingRemoveRangeRequest(
+          id: _id, startIndex: index, endIndex: index + 1, shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2498,12 +2358,8 @@ class ConcatenatingAudioSource extends AudioSource {
     _shuffleOrder.removeRange(start, end);
     if (_player != null) {
       _player!._broadcastSequence();
-      await (await _player!._platform).concatenatingRemoveRange(
-          ConcatenatingRemoveRangeRequest(
-              id: _id,
-              startIndex: start,
-              endIndex: end,
-              shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingRemoveRange(ConcatenatingRemoveRangeRequest(
+          id: _id, startIndex: start, endIndex: end, shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2514,12 +2370,8 @@ class ConcatenatingAudioSource extends AudioSource {
     _shuffleOrder.insert(newIndex, 1);
     if (_player != null) {
       _player!._broadcastSequence();
-      await (await _player!._platform).concatenatingMove(
-          ConcatenatingMoveRequest(
-              id: _id,
-              currentIndex: currentIndex,
-              newIndex: newIndex,
-              shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingMove(ConcatenatingMoveRequest(
+          id: _id, currentIndex: currentIndex, newIndex: newIndex, shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2530,12 +2382,8 @@ class ConcatenatingAudioSource extends AudioSource {
     _shuffleOrder.clear();
     if (_player != null) {
       _player!._broadcastSequence();
-      await (await _player!._platform).concatenatingRemoveRange(
-          ConcatenatingRemoveRangeRequest(
-              id: _id,
-              startIndex: 0,
-              endIndex: end,
-              shuffleOrder: List.of(_shuffleOrder.indices)));
+      await (await _player!._platform).concatenatingRemoveRange(ConcatenatingRemoveRangeRequest(
+          id: _id, startIndex: 0, endIndex: end, shuffleOrder: List.of(_shuffleOrder.indices)));
     }
   }
 
@@ -2545,8 +2393,7 @@ class ConcatenatingAudioSource extends AudioSource {
   AudioSource operator [](int index) => children[index];
 
   @override
-  List<IndexedAudioSource> get sequence =>
-      children.expand((s) => s.sequence).toList();
+  List<IndexedAudioSource> get sequence => children.expand((s) => s.sequence).toList();
 
   @override
   List<int> get shuffleIndices {
@@ -2598,11 +2445,7 @@ class ClippingAudioSource extends IndexedAudioSource {
 
   @override
   AudioSourceMessage _toMessage() => ClippingAudioSourceMessage(
-      id: _id,
-      child: child._toMessage() as UriAudioSourceMessage,
-      start: start,
-      end: end,
-      tag: tag);
+      id: _id, child: child._toMessage() as UriAudioSourceMessage, start: start, end: end, tag: tag);
 }
 
 // An [AudioSource] that loops a nested [AudioSource] a finite number of times.
@@ -2627,19 +2470,16 @@ class LoopingAudioSource extends AudioSource {
   void _shuffle({int? initialIndex}) {}
 
   @override
-  List<IndexedAudioSource> get sequence =>
-      List.generate(count, (i) => child).expand((s) => s.sequence).toList();
+  List<IndexedAudioSource> get sequence => List.generate(count, (i) => child).expand((s) => s.sequence).toList();
 
   @override
   List<int> get shuffleIndices => List.generate(count, (i) => i);
 
   @override
-  AudioSourceMessage _toMessage() => LoopingAudioSourceMessage(
-      id: _id, child: child._toMessage(), count: count);
+  AudioSourceMessage _toMessage() => LoopingAudioSourceMessage(id: _id, child: child._toMessage(), count: count);
 }
 
-Uri _encodeDataUrl(String base64Data, String mimeType) =>
-    Uri.parse('data:$mimeType;base64,$base64Data');
+Uri _encodeDataUrl(String base64Data, String mimeType) => Uri.parse('data:$mimeType;base64,$base64Data');
 
 /// An [AudioSource] that provides audio dynamically. Subclasses must override
 /// [request] to provide the encoded audio data. This API is experimental.
@@ -2653,8 +2493,7 @@ abstract class StreamAudioSource extends IndexedAudioSource {
     await super._setup(player);
     if (kIsWeb) {
       final response = await request();
-      _uri = _encodeDataUrl(await base64.encoder.bind(response.stream).join(),
-          response.contentType);
+      _uri = _encodeDataUrl(await base64.encoder.bind(response.stream).join(), response.contentType);
     } else {
       await player._proxy.ensureRunning();
       _uri = player._proxy.addStreamAudioSource(this);
@@ -2669,8 +2508,8 @@ abstract class StreamAudioSource extends IndexedAudioSource {
   Future<StreamAudioResponse> request([int? start, int? end]);
 
   @override
-  AudioSourceMessage _toMessage() => ProgressiveAudioSourceMessage(
-      id: _id, uri: _uri.toString(), headers: null, tag: tag);
+  AudioSourceMessage _toMessage() =>
+      ProgressiveAudioSourceMessage(id: _id, uri: _uri.toString(), headers: null, tag: tag);
 }
 
 /// The response for a [StreamAudioSource]. This API is experimental.
@@ -2736,8 +2575,7 @@ class LockCachingAudioSource extends StreamAudioSource {
     this.headers,
     File? cacheFile,
     dynamic tag,
-  })  : cacheFile =
-            cacheFile != null ? Future.value(cacheFile) : _getCacheFile(uri),
+  })  : cacheFile = cacheFile != null ? Future.value(cacheFile) : _getCacheFile(uri),
         super(tag: tag) {
     _init();
   }
@@ -2781,12 +2619,10 @@ class LockCachingAudioSource extends StreamAudioSource {
   static Future<File> _getCacheFile(final Uri uri) async => File(p.joinAll([
         (await _getCacheDir()).path,
         'remote',
-        sha256.convert(utf8.encode(uri.toString())).toString() +
-            p.extension(uri.path),
+        sha256.convert(utf8.encode(uri.toString())).toString() + p.extension(uri.path),
       ]));
 
-  Future<File> get _partialCacheFile async =>
-      File('${(await cacheFile).path}.part');
+  Future<File> get _partialCacheFile async => File('${(await cacheFile).path}.part');
 
   /// We use this to record the original content type of the downloaded audio.
   /// NOTE: We could instead rely on the cache file extension, but the original
@@ -2819,8 +2655,7 @@ class LockCachingAudioSource extends StreamAudioSource {
     final cacheFile = await this.cacheFile;
     final partialCacheFile = await _partialCacheFile;
 
-    File getEffectiveCacheFile() =>
-        partialCacheFile.existsSync() ? partialCacheFile : cacheFile;
+    File getEffectiveCacheFile() => partialCacheFile.existsSync() ? partialCacheFile : cacheFile;
 
     final httpClient = _createHttpClient(userAgent: _player?._userAgent);
     final httpRequest = await _getUrl(httpClient, uri, headers: headers);
@@ -2833,12 +2668,10 @@ class LockCachingAudioSource extends StreamAudioSource {
     // TODO: Should close sink after done, but it throws an error.
     // ignore: close_sinks
     final sink = (await _partialCacheFile).openWrite();
-    final sourceLength =
-        response.contentLength == -1 ? null : response.contentLength;
+    final sourceLength = response.contentLength == -1 ? null : response.contentLength;
     final mimeType = response.headers.contentType.toString();
     final acceptRanges = response.headers.value(HttpHeaders.acceptRangesHeader);
-    final originSupportsRangeRequests =
-        acceptRanges != null && acceptRanges != 'none';
+    final originSupportsRangeRequests = acceptRanges != null && acceptRanges != 'none';
     final mimeFile = await _mimeFile;
     await mimeFile.writeAsString(mimeType);
     final inProgressResponses = <_InProgressCacheResponse>[];
@@ -2862,24 +2695,17 @@ class LockCachingAudioSource extends StreamAudioSource {
       updateProgress(newPercentProgress);
       sink.add(data);
       final readyRequests = _requests
-          .where((request) =>
-              !originSupportsRangeRequests ||
-              request.start == null ||
-              (request.start!) < _progress)
+          .where((request) => !originSupportsRangeRequests || request.start == null || (request.start!) < _progress)
           .toList();
       final notReadyRequests = _requests
-          .where((request) =>
-              originSupportsRangeRequests &&
-              request.start != null &&
-              (request.start!) >= _progress)
+          .where((request) => originSupportsRangeRequests && request.start != null && (request.start!) >= _progress)
           .toList();
       // Add this live data to any responses in progress.
       for (var cacheResponse in inProgressResponses) {
         final end = cacheResponse.end;
         if (end != null && _progress >= end) {
           // We've received enough data to fulfill the byte range request.
-          final subEnd =
-              min(data.length, max(0, data.length - (_progress - end)));
+          final subEnd = min(data.length, max(0, data.length - (_progress - end)));
           cacheResponse.controller.add(data.sublist(0, subEnd));
           cacheResponse.controller.close();
         } else {
@@ -2908,8 +2734,7 @@ class LockCachingAudioSource extends StreamAudioSource {
         final effectiveEnd = end ?? sourceLength;
         Stream<List<int>> responseStream;
         if (effectiveEnd != null && effectiveEnd <= _progress) {
-          responseStream =
-              getEffectiveCacheFile().openRead(effectiveStart, effectiveEnd);
+          responseStream = getEffectiveCacheFile().openRead(effectiveStart, effectiveEnd);
         } else {
           final cacheResponse = _InProgressCacheResponse(end: effectiveEnd);
           inProgressResponses.add(cacheResponse);
@@ -2924,8 +2749,7 @@ class LockCachingAudioSource extends StreamAudioSource {
         request.complete(StreamAudioResponse(
           rangeRequestsSupported: originSupportsRangeRequests,
           sourceLength: start != null ? sourceLength : null,
-          contentLength:
-              effectiveEnd != null ? effectiveEnd - effectiveStart : null,
+          contentLength: effectiveEnd != null ? effectiveEnd - effectiveStart : null,
           offset: start,
           contentType: mimeType,
           stream: responseStream.asBroadcastStream(),
@@ -2972,12 +2796,18 @@ class LockCachingAudioSource extends StreamAudioSource {
           cacheResponse.controller.close();
         }
       }
-      (await _partialCacheFile).renameSync(cacheFile.path);
+      final partialCacheFile = await _partialCacheFile;
+      if (partialCacheFile.existsSync()) {
+        partialCacheFile.renameSync(cacheFile.path);
+      }
       await subscription.cancel();
       httpClient.close();
       _downloading = false;
     }, onError: (Object e, StackTrace stackTrace) async {
-      (await _partialCacheFile).deleteSync();
+      final partialCacheFile = await _partialCacheFile;
+      if (partialCacheFile.existsSync()) {
+        partialCacheFile.deleteSync();
+      }
       httpClient.close();
       // Fail all pending requests
       for (final req in _requests) {
@@ -3010,8 +2840,7 @@ class LockCachingAudioSource extends StreamAudioSource {
     }
     final byteRangeRequest = _StreamingByteRangeRequest(start, end);
     _requests.add(byteRangeRequest);
-    _response ??=
-        _fetch().catchError((dynamic error, StackTrace? stackTrace) async {
+    _response ??= _fetch().catchError((dynamic error, StackTrace? stackTrace) async {
       // So that we can restart later
       _response = null;
       // Cancel any pending request
@@ -3088,22 +2917,19 @@ class _StreamingByteRangeRequest {
 }
 
 /// The type of functions that can handle HTTP requests sent to the proxy.
-typedef _ProxyHandler = void Function(
-    _ProxyHttpServer server, HttpRequest request);
+typedef _ProxyHandler = void Function(_ProxyHttpServer server, HttpRequest request);
 
 /// A proxy handler for serving audio from a [StreamAudioSource].
 _ProxyHandler _proxyHandlerForSource(StreamAudioSource source) {
   Future<void> handler(_ProxyHttpServer server, HttpRequest request) async {
-    final rangeRequest =
-        _HttpRangeRequest.parse(request.headers[HttpHeaders.rangeHeader]);
+    final rangeRequest = _HttpRangeRequest.parse(request.headers[HttpHeaders.rangeHeader]);
 
     request.response.headers.clear();
 
     StreamAudioResponse sourceResponse;
     Stream<List<int>> stream;
     try {
-      sourceResponse =
-          await source.request(rangeRequest?.start, rangeRequest?.endEx);
+      sourceResponse = await source.request(rangeRequest?.start, rangeRequest?.endEx);
       stream = sourceResponse.stream;
     } catch (e, st) {
       // ignore: avoid_print
@@ -3115,21 +2941,17 @@ _ProxyHandler _proxyHandlerForSource(StreamAudioSource source) {
       return;
     }
 
-    request.response.headers
-        .set(HttpHeaders.contentTypeHeader, sourceResponse.contentType);
+    request.response.headers.set(HttpHeaders.contentTypeHeader, sourceResponse.contentType);
 
     if (sourceResponse.rangeRequestsSupported) {
       request.response.headers.set(HttpHeaders.acceptRangesHeader, 'bytes');
     }
 
     if (rangeRequest != null && sourceResponse.offset != null) {
-      final range = _HttpRangeResponse(
-          sourceResponse.offset!,
-          sourceResponse.offset! + sourceResponse.contentLength! - 1,
-          sourceResponse.sourceLength);
+      final range = _HttpRangeResponse(sourceResponse.offset!,
+          sourceResponse.offset! + sourceResponse.contentLength! - 1, sourceResponse.sourceLength);
       request.response.contentLength = range.length ?? -1;
-      request.response.headers
-          .set(HttpHeaders.contentRangeHeader, range.header);
+      request.response.headers.set(HttpHeaders.contentRangeHeader, range.header);
       request.response.statusCode = 206;
     } else {
       request.response.contentLength = sourceResponse.contentLength ?? -1;
@@ -3171,10 +2993,8 @@ _ProxyHandler _proxyHandlerForUri(
     String? host;
     try {
       final requestHeaders = <String, String>{if (headers != null) ...headers};
-      request.headers
-          .forEach((name, value) => requestHeaders[name] = value.join(', '));
-      final originRequest =
-          await _getUrl(client, redirectedUri ?? uri, headers: requestHeaders);
+      request.headers.forEach((name, value) => requestHeaders[name] = value.join(', '));
+      final originRequest = await _getUrl(client, redirectedUri ?? uri, headers: requestHeaders);
       host = originRequest.headers.value(HttpHeaders.hostHeader);
       final originResponse = await originRequest.close();
       if (originResponse.redirects.isNotEmpty) {
@@ -3183,9 +3003,7 @@ _ProxyHandler _proxyHandlerForUri(
 
       request.response.headers.clear();
       originResponse.headers.forEach((name, value) {
-        final filteredValue = value
-            .map((e) => e.replaceAll(RegExp(r'[^\x09\x20-\x7F]'), '?'))
-            .toList();
+        final filteredValue = value.map((e) => e.replaceAll(RegExp(r'[^\x09\x20-\x7F]'), '?')).toList();
         request.response.headers.set(name, filteredValue);
       });
       request.response.statusCode = originResponse.statusCode;
@@ -3198,8 +3016,7 @@ _ProxyHandler _proxyHandlerForUri(
         // TODO: Handle other playlist formats similarly?
         final m3u8 = await originResponse.transform(utf8.decoder).join();
         for (var line in const LineSplitter().convert(m3u8)) {
-          line = line.replaceAllMapped(
-              RegExp(r'#EXT-X-MEDIA:.*?URI="(.*?)".*'), (m) => m[1]!);
+          line = line.replaceAllMapped(RegExp(r'#EXT-X-MEDIA:.*?URI="(.*?)".*'), (m) => m[1]!);
           line = line.replaceAll(RegExp(r'#.*$'), '').trim();
           if (line.isEmpty) continue;
           try {
@@ -3209,13 +3026,9 @@ _ProxyHandler _proxyHandlerForUri(
               server.addUriAudioSource(AudioSource.uri(rawNestedUri));
             } else {
               // This is a resource on the same server, so propagate the headers.
-              final basePath = rawNestedUri.path.startsWith('/')
-                  ? ''
-                  : uri.path.replaceAll(RegExp(r'/[^/]*$'), '/');
-              final nestedUri =
-                  uri.replace(path: '$basePath${rawNestedUri.path}');
-              server.addUriAudioSource(
-                  AudioSource.uri(nestedUri, headers: headers));
+              final basePath = rawNestedUri.path.startsWith('/') ? '' : uri.path.replaceAll(RegExp(r'/[^/]*$'), '/');
+              final nestedUri = uri.replace(path: '$basePath${rawNestedUri.path}');
+              server.addUriAudioSource(AudioSource.uri(nestedUri, headers: headers));
             }
           } catch (e) {
             // ignore malformed lines
@@ -3240,8 +3053,7 @@ _ProxyHandler _proxyHandlerForUri(
         // Try parsing HTTP 0.9 response
         //request.response.headers.clear();
         final socket = await Socket.connect(uri.host, uri.port);
-        final clientSocket =
-            await request.response.detachSocket(writeHeaders: false);
+        final clientSocket = await request.response.detachSocket(writeHeaders: false);
         final done = Completer<dynamic>();
         socket.listen(
           clientSocket.add,
@@ -3279,8 +3091,7 @@ _ProxyHandler _proxyHandlerForUri(
   return handler;
 }
 
-Future<Directory> _getCacheDir() async =>
-    Directory(p.join((await getTemporaryDirectory()).path, 'just_audio_cache'));
+Future<Directory> _getCacheDir() async => Directory(p.join((await getTemporaryDirectory()).path, 'just_audio_cache'));
 
 /// Defines the algorithm for shuffling the order of a
 /// [ConcatenatingAudioSource]. See [DefaultShuffleOrder] for a default
@@ -3403,13 +3214,10 @@ class _IdleAudioPlayer extends AudioPlayerPlatform {
   }
 
   Duration? _getDurationAtIndex(int? index) =>
-      index != null && _sequence != null && index < _sequence!.length
-          ? _sequence![index].duration
-          : null;
+      index != null && _sequence != null && index < _sequence!.length ? _sequence![index].duration : null;
 
   @override
-  Stream<PlaybackEventMessage> get playbackEventMessageStream =>
-      _eventSubject.stream;
+  Stream<PlaybackEventMessage> get playbackEventMessageStream => _eventSubject.stream;
 
   @override
   Future<LoadResponse> load(LoadRequest request) async {
@@ -3445,8 +3253,7 @@ class _IdleAudioPlayer extends AudioPlayerPlatform {
   }
 
   @override
-  Future<SetSkipSilenceResponse> setSkipSilence(
-      SetSkipSilenceRequest request) async {
+  Future<SetSkipSilenceResponse> setSkipSilence(SetSkipSilenceRequest request) async {
     return SetSkipSilenceResponse();
   }
 
@@ -3456,35 +3263,30 @@ class _IdleAudioPlayer extends AudioPlayerPlatform {
   }
 
   @override
-  Future<SetShuffleModeResponse> setShuffleMode(
-      SetShuffleModeRequest request) async {
+  Future<SetShuffleModeResponse> setShuffleMode(SetShuffleModeRequest request) async {
     return SetShuffleModeResponse();
   }
 
   @override
-  Future<SetShuffleOrderResponse> setShuffleOrder(
-      SetShuffleOrderRequest request) async {
+  Future<SetShuffleOrderResponse> setShuffleOrder(SetShuffleOrderRequest request) async {
     return SetShuffleOrderResponse();
   }
 
   @override
-  Future<SetAutomaticallyWaitsToMinimizeStallingResponse>
-      setAutomaticallyWaitsToMinimizeStalling(
-          SetAutomaticallyWaitsToMinimizeStallingRequest request) async {
+  Future<SetAutomaticallyWaitsToMinimizeStallingResponse> setAutomaticallyWaitsToMinimizeStalling(
+      SetAutomaticallyWaitsToMinimizeStallingRequest request) async {
     return SetAutomaticallyWaitsToMinimizeStallingResponse();
   }
 
   @override
   Future<SetCanUseNetworkResourcesForLiveStreamingWhilePausedResponse>
       setCanUseNetworkResourcesForLiveStreamingWhilePaused(
-          SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest
-              request) async {
+          SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest request) async {
     return SetCanUseNetworkResourcesForLiveStreamingWhilePausedResponse();
   }
 
   @override
-  Future<SetPreferredPeakBitRateResponse> setPreferredPeakBitRate(
-      SetPreferredPeakBitRateRequest request) async {
+  Future<SetPreferredPeakBitRateResponse> setPreferredPeakBitRate(SetPreferredPeakBitRateRequest request) async {
     return SetPreferredPeakBitRateResponse();
   }
 
@@ -3497,8 +3299,7 @@ class _IdleAudioPlayer extends AudioPlayerPlatform {
   }
 
   @override
-  Future<SetAndroidAudioAttributesResponse> setAndroidAudioAttributes(
-      SetAndroidAudioAttributesRequest request) async {
+  Future<SetAndroidAudioAttributesResponse> setAndroidAudioAttributes(SetAndroidAudioAttributesRequest request) async {
     setAndroidAudioAttributesRequest = request;
     return SetAndroidAudioAttributesResponse();
   }
@@ -3509,33 +3310,28 @@ class _IdleAudioPlayer extends AudioPlayerPlatform {
   }
 
   @override
-  Future<ConcatenatingInsertAllResponse> concatenatingInsertAll(
-      ConcatenatingInsertAllRequest request) async {
+  Future<ConcatenatingInsertAllResponse> concatenatingInsertAll(ConcatenatingInsertAllRequest request) async {
     return ConcatenatingInsertAllResponse();
   }
 
   @override
-  Future<ConcatenatingRemoveRangeResponse> concatenatingRemoveRange(
-      ConcatenatingRemoveRangeRequest request) async {
+  Future<ConcatenatingRemoveRangeResponse> concatenatingRemoveRange(ConcatenatingRemoveRangeRequest request) async {
     return ConcatenatingRemoveRangeResponse();
   }
 
   @override
-  Future<ConcatenatingMoveResponse> concatenatingMove(
-      ConcatenatingMoveRequest request) async {
+  Future<ConcatenatingMoveResponse> concatenatingMove(ConcatenatingMoveRequest request) async {
     return ConcatenatingMoveResponse();
   }
 
   @override
-  Future<AudioEffectSetEnabledResponse> audioEffectSetEnabled(
-      AudioEffectSetEnabledRequest request) async {
+  Future<AudioEffectSetEnabledResponse> audioEffectSetEnabled(AudioEffectSetEnabledRequest request) async {
     return AudioEffectSetEnabledResponse();
   }
 
   @override
-  Future<AndroidLoudnessEnhancerSetTargetGainResponse>
-      androidLoudnessEnhancerSetTargetGain(
-          AndroidLoudnessEnhancerSetTargetGainRequest request) async {
+  Future<AndroidLoudnessEnhancerSetTargetGainResponse> androidLoudnessEnhancerSetTargetGain(
+      AndroidLoudnessEnhancerSetTargetGainRequest request) async {
     return AndroidLoudnessEnhancerSetTargetGainResponse();
   }
 }
@@ -3556,15 +3352,12 @@ class AudioPipeline {
   AudioPipeline({
     List<AndroidAudioEffect>? androidAudioEffects,
     List<DarwinAudioEffect>? darwinAudioEffects,
-  })  : assert(androidAudioEffects == null ||
-            androidAudioEffects.toSet().length == androidAudioEffects.length),
-        assert(darwinAudioEffects == null ||
-            darwinAudioEffects.toSet().length == darwinAudioEffects.length),
+  })  : assert(androidAudioEffects == null || androidAudioEffects.toSet().length == androidAudioEffects.length),
+        assert(darwinAudioEffects == null || darwinAudioEffects.toSet().length == darwinAudioEffects.length),
         androidAudioEffects = androidAudioEffects ?? const [],
         darwinAudioEffects = darwinAudioEffects ?? const [];
 
-  List<AudioEffect> get _audioEffects =>
-      <AudioEffect>[...androidAudioEffects, ...darwinAudioEffects];
+  List<AudioEffect> get _audioEffects => <AudioEffect>[...androidAudioEffects, ...darwinAudioEffects];
 
   void _setup(AudioPlayer player) {
     for (var effect in _audioEffects) {
@@ -3612,8 +3405,8 @@ abstract class AudioEffect {
   Future<void> setEnabled(bool enabled) async {
     _enabledSubject.add(enabled);
     if (_active) {
-      await (await _player!._platform).audioEffectSetEnabled(
-          AudioEffectSetEnabledRequest(type: _type, enabled: enabled));
+      await (await _player!._platform)
+          .audioEffectSetEnabled(AudioEffectSetEnabledRequest(type: _type, enabled: enabled));
     }
   }
 
@@ -3644,8 +3437,8 @@ class AndroidLoudnessEnhancer extends AudioEffect with AndroidAudioEffect {
   Future<void> setTargetGain(double targetGain) async {
     _targetGainSubject.add(targetGain);
     if (_active) {
-      await (await _player!._platform).androidLoudnessEnhancerSetTargetGain(
-          AndroidLoudnessEnhancerSetTargetGainRequest(targetGain: targetGain));
+      await (await _player!._platform)
+          .androidLoudnessEnhancerSetTargetGain(AndroidLoudnessEnhancerSetTargetGainRequest(targetGain: targetGain));
     }
   }
 
@@ -3694,19 +3487,17 @@ class AndroidEqualizerBand {
   Future<void> setGain(double gain) async {
     _gainSubject.add(gain);
     if (_player._active) {
-      await (await _player._platform).androidEqualizerBandSetGain(
-          AndroidEqualizerBandSetGainRequest(bandIndex: index, gain: gain));
+      await (await _player._platform)
+          .androidEqualizerBandSetGain(AndroidEqualizerBandSetGainRequest(bandIndex: index, gain: gain));
     }
   }
 
   /// Restores the gain after reactivating.
   Future<void> _restore(AudioPlayerPlatform platform) async {
-    await (platform).androidEqualizerBandSetGain(
-        AndroidEqualizerBandSetGainRequest(bandIndex: index, gain: gain));
+    await (platform).androidEqualizerBandSetGain(AndroidEqualizerBandSetGainRequest(bandIndex: index, gain: gain));
   }
 
-  static AndroidEqualizerBand _fromMessage(
-          AudioPlayer player, AndroidEqualizerBandMessage message) =>
+  static AndroidEqualizerBand _fromMessage(AudioPlayer player, AndroidEqualizerBandMessage message) =>
       AndroidEqualizerBand._(
         player: player,
         index: message.index,
@@ -3741,23 +3532,18 @@ class AndroidEqualizerParameters {
     }
   }
 
-  static AndroidEqualizerParameters _fromMessage(
-          AudioPlayer player, AndroidEqualizerParametersMessage message) =>
+  static AndroidEqualizerParameters _fromMessage(AudioPlayer player, AndroidEqualizerParametersMessage message) =>
       AndroidEqualizerParameters(
         minDecibels: message.minDecibels,
         maxDecibels: message.maxDecibels,
-        bands: message.bands
-            .map((bandMessage) =>
-                AndroidEqualizerBand._fromMessage(player, bandMessage))
-            .toList(),
+        bands: message.bands.map((bandMessage) => AndroidEqualizerBand._fromMessage(player, bandMessage)).toList(),
       );
 }
 
 /// An [AudioEffect] for Android that can adjust the gain for different
 /// frequency bands of an [AudioPlayer]'s audio signal.
 class AndroidEqualizer extends AudioEffect with AndroidAudioEffect {
-  final Completer<AndroidEqualizerParameters> _parametersCompleter =
-      Completer<AndroidEqualizerParameters>();
+  final Completer<AndroidEqualizerParameters> _parametersCompleter = Completer<AndroidEqualizerParameters>();
 
   @override
   String get _type => 'AndroidEqualizer';
@@ -3769,16 +3555,13 @@ class AndroidEqualizer extends AudioEffect with AndroidAudioEffect {
       await (await parameters)._restore(platform);
       return;
     }
-    final response = await platform
-        .androidEqualizerGetParameters(AndroidEqualizerGetParametersRequest());
-    final receivedParameters =
-        AndroidEqualizerParameters._fromMessage(_player!, response.parameters);
+    final response = await platform.androidEqualizerGetParameters(AndroidEqualizerGetParametersRequest());
+    final receivedParameters = AndroidEqualizerParameters._fromMessage(_player!, response.parameters);
     _parametersCompleter.complete(receivedParameters);
   }
 
   /// The parameter values of this equalizer.
-  Future<AndroidEqualizerParameters> get parameters =>
-      _parametersCompleter.future;
+  Future<AndroidEqualizerParameters> get parameters => _parametersCompleter.future;
 
   @override
   AudioEffectMessage _toMessage() => AndroidEqualizerMessage(
@@ -3822,8 +3605,7 @@ enum PositionDiscontinuityReason {
   autoAdvance,
 }
 
-Future<HttpClientRequest> _getUrl(HttpClient client, Uri uri,
-    {Map<String, String>? headers}) async {
+Future<HttpClientRequest> _getUrl(HttpClient client, Uri uri, {Map<String, String>? headers}) async {
   final request = await client.getUrl(uri);
   if (headers != null) {
     final host = request.headers.value(HttpHeaders.hostHeader);


### PR DESCRIPTION
Relevant issue: https://github.com/ryanheise/just_audio/issues/1032

I have this issue littered throughout my sentry logs. I can sometimes replicate it by setting a LockCachingAudioSource and then disposing of the audio player almost immediately afterwards. It appears that just_audio attempts to rename (or delete on error) the partial cache file, but does so without first checking to see if it exists. This pull request simply ensures the partial cache file exists before attempting to rename or delete it.