### PR TITLE
Fix headers passed as null with uri source on iOS

### DIFF
--- a/just_audio/darwin/Classes/AudioPlayer.m
+++ b/just_audio/darwin/Classes/AudioPlayer.m
@@ -452,12 +452,13 @@
 
 - (AudioSource *)decodeAudioSource:(NSDictionary *)data {
     NSString *type = data[@"type"];
-    if ([@"progressive" isEqualToString:type]) {
-        return [[UriAudioSource alloc] initWithId:data[@"id"] uri:data[@"uri"] loadControl:_loadControl headers:data[@"headers"]];
-    } else if ([@"dash" isEqualToString:type]) {
-        return [[UriAudioSource alloc] initWithId:data[@"id"] uri:data[@"uri"] loadControl:_loadControl headers:data[@"headers"]];
-    } else if ([@"hls" isEqualToString:type]) {
-        return [[UriAudioSource alloc] initWithId:data[@"id"] uri:data[@"uri"] loadControl:_loadControl headers:data[@"headers"]];
+    if ([@"progressive" isEqualToString:type] || [@"dash" isEqualToString:type] || [@"hls" isEqualToString:type]) {
+        id headers = data[@"headers"];
+        if (![headers isKindOfClass: [NSDictionary class]]) {
+            // e.g. NSNull
+            headers = nil;
+        }
+        return [[UriAudioSource alloc] initWithId:data[@"id"] uri:data[@"uri"] loadControl:_loadControl headers: headers];
     } else if ([@"concatenating" isEqualToString:type]) {
         return [[ConcatenatingAudioSource alloc] initWithId:data[@"id"]
                                                audioSources:[self decodeAudioSources:data[@"children"]]


### PR DESCRIPTION
`data[@"headers"]` is not nil, but `NSNull` by default, which will cause an exception in the `initWithId: ...` call