### PR TITLE
Fix: NotAllowedError can be captured by try-catch

### DIFF
--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -961,10 +961,15 @@ class _PlayPauseQueue {
 
   Future<void> _run() async {
     await for (var request in _queue.stream) {
-      if (request.playing) {
-        await audioElement.play();
-      } else {
-        audioElement.pause();
+      try {
+        if (request.playing) {
+          await audioElement.play();
+        } else {
+          audioElement.pause();
+        }
+      } catch (err) {
+        request.completer.completeError(err);
+        continue;
       }
       request.completer.complete();
     }


### PR DESCRIPTION
Relevant issue: #1121 