### PR TITLE
iOS - Added Privacy Manifests

### DIFF
--- a/just_audio/ios/Resources/PrivacyInfo.xcprivacy
+++ b/just_audio/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/just_audio/ios/just_audio.podspec
+++ b/just_audio/ios/just_audio.podspec
@@ -17,5 +17,6 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.platform = :ios, '8.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.resource_bundles = {'just_audio' => ['Resources/PrivacyInfo.xcprivacy']}
 end
 

--- a/just_audio_background/ios/Resources/PrivacyInfo.xcprivacy
+++ b/just_audio_background/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/just_audio_background/ios/just_audio_web.podspec
+++ b/just_audio_background/ios/just_audio_web.podspec
@@ -17,4 +17,5 @@ temp fake just_audio_web plugin
   s.dependency 'Flutter'
 
   s.ios.deployment_target = '8.0'
+  s.resource_bundles = {'just_audio_web' => ['Resources/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
# Summary
Added an empty Privacy Manifest to the iOS project in preparation for the May 1st Deadline for 3rd Party SDKs that include native iOS code. 

# Description

> Starting May 1: You’ll need to include approved reasons for the listed APIs used by your app’s code to upload a new or updated app to App Store Connect.
> ...
> Make sure to use a version of the SDK that includes its privacy manifest and note that signatures are also required when the SDK is added as a binary dependency.

[Privacy updates for App Store submissions - Latest News - Apple Developer](https://developer.apple.com/news/?id=3d8a9yyh)
[Upcoming third-party SDK requirements - Support - Apple Developer](https://developer.apple.com/support/third-party-SDK-requirements/)

# Impact and Testing
Developers using an updated version of this library on their iOS projects shouldn't see any issues related to the Privacy Manifest

# Contributor Note
Based on the language on Apple's Website, this change seems to be mandatory for all 3rd Party Libraries. The impact of not adding it is unclear to me, but hopefully having it will be better than not.