### PR TITLE
[just_audio_background] Fix: Shuffle order out of sync after inserting/removing item from ConcatenatingAudioSource

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -2543,12 +2543,13 @@ class ConcatenatingAudioSource extends AudioSource {
     if (_player != null) {
       _player!._broadcastSequence();
       await audioSource._setup(_player!);
-      await (await _player!._platform).concatenatingInsertAll(
-          ConcatenatingInsertAllRequest(
-              id: _id,
-              index: index,
-              children: [audioSource._toMessage()],
-              shuffleOrder: List.of(_shuffleOrder.indices)));
+      ConcatenatingInsertAllRequest request = ConcatenatingInsertAllRequest(
+        id: _id,
+        index: index,
+        children: [audioSource._toMessage()],
+        shuffleOrder: List.of(_shuffleOrder.indices)
+      );
+      await (await _player!._platform).concatenatingInsertAll(request);
     }
   }
 
@@ -2596,12 +2597,13 @@ class ConcatenatingAudioSource extends AudioSource {
     _shuffleOrder.removeRange(index, index + 1);
     if (_player != null) {
       _player!._broadcastSequence();
-      await (await _player!._platform).concatenatingRemoveRange(
-          ConcatenatingRemoveRangeRequest(
-              id: _id,
-              startIndex: index,
-              endIndex: index + 1,
-              shuffleOrder: List.of(_shuffleOrder.indices)));
+      ConcatenatingRemoveRangeRequest request = ConcatenatingRemoveRangeRequest(
+        id: _id,
+        startIndex: index,
+        endIndex: index + 1,
+        shuffleOrder: List.of(_shuffleOrder.indices)
+      );
+      await (await _player!._platform).concatenatingRemoveRange(request);
     }
   }
 

--- a/just_audio_background/lib/just_audio_background.dart
+++ b/just_audio_background/lib/just_audio_background.dart
@@ -511,6 +511,8 @@ class _PlayerAudioHandler extends BaseAudioHandler
       ConcatenatingInsertAllRequest request) async {
     final cat = _source!.findCat(request.id)!;
     cat.children.insertAll(request.index, request.children);
+	  cat.shuffleOrder.clear();
+	  cat.shuffleOrder.addAll(request.shuffleOrder);
     _updateShuffleIndices();
     _broadcastStateIfActive();
     _updateQueue();
@@ -521,6 +523,8 @@ class _PlayerAudioHandler extends BaseAudioHandler
       ConcatenatingRemoveRangeRequest request) async {
     final cat = _source!.findCat(request.id)!;
     cat.children.removeRange(request.startIndex, request.endIndex);
+	  cat.shuffleOrder.clear();
+  	cat.shuffleOrder.addAll(request.shuffleOrder);
     _updateShuffleIndices();
     _broadcastStateIfActive();
     _updateQueue();


### PR DESCRIPTION
When calling `insert()` or `removeAt()` on a `ConcatenatingAudioSource`, a new `shuffleOrder` is passed with the request but it is not updated in just_audio_background's corresponding `ConcatenatingAudioSourceMessage`. This results in the shuffle order being out of sync, which can cause issues such as an out of range exception in the case of `removeAt()`.

This PR also includes a change to just_audio which I found was necessary to resolve the issue I was experiencing with `removeAt()`, though I'm not sure why it seemed to make a difference.