### PR TITLE
Add cross origin setting to HTML5 AudioElement

### DIFF
--- a/just_audio/README.md
+++ b/just_audio/README.md
@@ -436,7 +436,7 @@ Please also consider pressing the thumbs up button at the top of [this page](htt
 | read from file                 | ✅      | ✅  | ✅    | ✅  | ✅      | ✅    |
 | read from asset                | ✅      | ✅  | ✅    | ✅  | ✅      | ✅    |
 | read from byte stream          | ✅      | ✅  | ✅    | ✅  | ✅      | ✅    |
-| request headers                | ✅      | ✅  | ✅    |     | ✅      | ✅    |
+| request headers                | ✅      | ✅  | ✅    | [^1] | ✅     | ✅    |
 | DASH                           | ✅      |     |       |     | ✅      | ✅    |
 | HLS                            | ✅      | ✅  | ✅    |     | ✅      | ✅    |
 | ICY metadata                   | ✅      | ✅  | ✅    |     |         |       |
@@ -455,6 +455,10 @@ Please also consider pressing the thumbs up button at the top of [this page](htt
 | skip silence                   | ✅      |     |       |     |         |       |
 | equalizer                      | ✅      |     |       |     |         | ✅    |
 | volume boost                   | ✅      |     |       |     |         | ✅    |
+
+[^1]: While headers cannot be set directly, cookies can be used to send information in the [Cookie header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie).
+See also `setWebCrossOrigin` to send cookies when loading audio files from a different origin (see [HTMLMediaElement crossOrigin](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/crossOrigin)).
+
 
 ## Experimental features
 

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1196,6 +1196,18 @@ class AudioPlayer {
         usage: audioAttributes.usage.value));
   }
 
+  Future<void> setWebCrossOrigin(bool useCredentials) async {
+    if (_disposed) return;
+    if (!kIsWeb && !_isUnitTest()) return;
+    final WebCrossOriginMessage crossOriginMsg = useCredentials
+        ? WebCrossOriginMessage.useCredentials
+        : WebCrossOriginMessage.anonymous;
+
+    await (await _platform).webSetCrossOrigin(
+      WebSetCrossOriginRequest(crossOrigin: crossOriginMsg),
+    );
+  }
+
   /// Release all resources associated with this player. You must invoke this
   /// after you are done with the player.
   Future<void> dispose() async {

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and concatenate any sound from any source (asset/file/URL/stream) in a variety of audio formats with gapless playback.
-version: 0.9.39
+version: 0.9.38
 repository: https://github.com/ryanheise/just_audio/tree/minor/just_audio
 issue_tracker: https://github.com/ryanheise/just_audio/issues
 topics:

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and concatenate any sound from any source (asset/file/URL/stream) in a variety of audio formats with gapless playback.
-version: 0.9.38
+version: 0.9.39
 repository: https://github.com/ryanheise/just_audio/tree/minor/just_audio
 issue_tracker: https://github.com/ryanheise/just_audio/issues
 topics:
@@ -17,7 +17,7 @@ dependencies:
   just_audio_platform_interface: ^4.2.3
   # just_audio_platform_interface:
   #   path: ../just_audio_platform_interface
-  just_audio_web: ^0.4.10
+  just_audio_web: ^0.4.11
   # just_audio_web:
   #   path: ../just_audio_web
   audio_session: ^0.1.14

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and concatenate any sound from any source (asset/file/URL/stream) in a variety of audio formats with gapless playback.
-version: 0.9.37
+version: 0.9.38
 repository: https://github.com/ryanheise/just_audio/tree/minor/just_audio
 issue_tracker: https://github.com/ryanheise/just_audio/issues
 topics:
@@ -14,10 +14,10 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  just_audio_platform_interface: ^4.2.2
+  just_audio_platform_interface: ^4.2.3
   # just_audio_platform_interface:
   #   path: ../just_audio_platform_interface
-  just_audio_web: ^0.4.9
+  just_audio_web: ^0.4.10
   # just_audio_web:
   #   path: ../just_audio_web
   audio_session: ^0.1.14

--- a/just_audio_background/pubspec.yaml
+++ b/just_audio_background/pubspec.yaml
@@ -1,7 +1,7 @@
 name: just_audio_background
 description: An add-on for just_audio that supports background playback and media notifications.
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_background
-version: 0.0.1-beta.11
+version: 0.0.1-beta.12
 topics:
   - audio
   - sound
@@ -9,7 +9,7 @@ topics:
   - background
 
 dependencies:
-  just_audio_platform_interface: ^4.2.2
+  just_audio_platform_interface: ^4.2.3
   # just_audio_platform_interface:
   #   path: ../just_audio_platform_interface
   audio_service: ^0.18.9

--- a/just_audio_platform_interface/lib/just_audio_platform_interface.dart
+++ b/just_audio_platform_interface/lib/just_audio_platform_interface.dart
@@ -230,6 +230,12 @@ abstract class AudioPlayerPlatform {
     throw UnimplementedError(
         "androidEqualizerBandSetGain() has not been implemented.");
   }
+
+  /// Sets the 'crossOrigin' attribute on the web audio element.
+  Future<WebSetCrossOriginResponse> webSetCrossOrigin(
+      WebSetCrossOriginRequest request) {
+    throw UnimplementedError("webSetCrossOrigin() has not been implemented.");
+  }
 }
 
 /// A data update communicated from the platform implementation to the Flutter
@@ -1485,3 +1491,16 @@ class AndroidEqualizerMessage extends AudioEffectMessage {
         'parameters': parameters?.toMap(),
       };
 }
+
+class WebSetCrossOriginRequest {
+  final WebCrossOriginMessage crossOrigin;
+
+  WebSetCrossOriginRequest({required this.crossOrigin});
+}
+
+class WebSetCrossOriginResponse {
+  static WebSetCrossOriginResponse fromMap(Map<dynamic, dynamic> map) =>
+      WebSetCrossOriginResponse();
+}
+
+enum WebCrossOriginMessage { anonymous, useCredentials }

--- a/just_audio_platform_interface/pubspec.yaml
+++ b/just_audio_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the just_audio plugin. Different pl
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.2.2
+version: 4.2.3
 
 dependencies:
   flutter:

--- a/just_audio_web/CHANGELOG.md
+++ b/just_audio_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.11
 
-* Allow to set `crossorigin` on the HTML `<audio />` element (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin))
+* Allow to set `crossorigin` on the HTML `<audio />` element (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/crossOrigin))
 
 ## 0.4.10
 

--- a/just_audio_web/CHANGELOG.md
+++ b/just_audio_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.11
+
+* Allow to set `crossorigin` on the HTML `<audio />` element (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin))
+
 ## 0.4.10
 
 * Migrate to package:web.

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -328,6 +328,21 @@ class Html5AudioPlayer extends JustAudioPlayer {
     return SetShuffleOrderResponse();
   }
 
+  Future<SetCrossOriginResponse> setCrossOrigin(
+      SetCrossOriginRequest request) async {
+    switch (request.crossOrigin) {
+      case CrossOriginMessage.anonymous:
+        _audioElement.crossOrigin = 'anonymous';
+        break;
+      case CrossOriginMessage.useCredentials:
+        _audioElement.crossOrigin = 'use-credentials';
+        break;
+      default:
+        throw Exception("Unknown CrossOriginMessage: $request.crossOrigin");
+    }
+    return SetCrossOriginResponse();
+  }
+
   @override
   Future<SeekResponse> seek(SeekRequest request) async {
     await _seek(request.position?.inMilliseconds ?? 0, request.index);
@@ -974,3 +989,16 @@ class _PlayPauseQueue {
     }
   }
 }
+
+class SetCrossOriginRequest {
+  final CrossOriginMessage crossOrigin;
+
+  SetCrossOriginRequest({required this.crossOrigin});
+}
+
+class SetCrossOriginResponse {
+  static SetCrossOriginResponse fromMap(Map<dynamic, dynamic> map) =>
+      SetCrossOriginResponse();
+}
+
+enum CrossOriginMessage { anonymous, useCredentials }

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -328,19 +328,20 @@ class Html5AudioPlayer extends JustAudioPlayer {
     return SetShuffleOrderResponse();
   }
 
-  Future<SetCrossOriginResponse> setCrossOrigin(
-      SetCrossOriginRequest request) async {
+  @override
+  Future<WebSetCrossOriginResponse> webSetCrossOrigin(
+      WebSetCrossOriginRequest request) async {
     switch (request.crossOrigin) {
-      case CrossOriginMessage.anonymous:
+      case WebCrossOriginMessage.anonymous:
         _audioElement.crossOrigin = 'anonymous';
         break;
-      case CrossOriginMessage.useCredentials:
+      case WebCrossOriginMessage.useCredentials:
         _audioElement.crossOrigin = 'use-credentials';
         break;
       default:
         throw Exception("Unknown CrossOriginMessage: $request.crossOrigin");
     }
-    return SetCrossOriginResponse();
+    return WebSetCrossOriginResponse();
   }
 
   @override
@@ -989,16 +990,3 @@ class _PlayPauseQueue {
     }
   }
 }
-
-class SetCrossOriginRequest {
-  final CrossOriginMessage crossOrigin;
-
-  SetCrossOriginRequest({required this.crossOrigin});
-}
-
-class SetCrossOriginResponse {
-  static SetCrossOriginResponse fromMap(Map<dynamic, dynamic> map) =>
-      SetCrossOriginResponse();
-}
-
-enum CrossOriginMessage { anonymous, useCredentials }

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -18,11 +18,11 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  web: ">=0.3.0 <0.5.0"
+  web: '>=0.3.0 <0.5.0'
 
 dev_dependencies:
   flutter_lints: ^2.0.1
 
 environment:
   sdk: ^3.2.1
-  flutter: ">=3.16.0"
+  flutter: '>=3.16.0'

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: just_audio_web
 description: Web platform implementation of just_audio. This implementation is endorsed and therefore doesn't require a direct dependency.
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_web
-version: 0.4.9
+version: 0.4.10
 
 flutter:
   plugin:
@@ -11,9 +11,9 @@ flutter:
         fileName: just_audio_web.dart
 
 dependencies:
-  # just_audio_platform_interface: ^4.2.2
-  just_audio_platform_interface:
-    path: ../just_audio_platform_interface
+  just_audio_platform_interface: ^4.2.3
+  # just_audio_platform_interface:
+  #   path: ../just_audio_platform_interface
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: just_audio_web
 description: Web platform implementation of just_audio. This implementation is endorsed and therefore doesn't require a direct dependency.
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_web
-version: 0.4.10
+version: 0.4.11
 
 flutter:
   plugin:
@@ -18,7 +18,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  web: '>=0.3.0 <0.5.0'
+  web: ">=0.3.0 <0.5.0"
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -11,9 +11,9 @@ flutter:
         fileName: just_audio_web.dart
 
 dependencies:
-  just_audio_platform_interface: ^4.2.2
-  # just_audio_platform_interface:
-  #   path: ../just_audio_platform_interface
+  # just_audio_platform_interface: ^4.2.2
+  just_audio_platform_interface:
+    path: ../just_audio_platform_interface
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**


Currently there is no support for headers in the just audio web player

One way to use authenticated audio sources on the web are using authentication cookies.

If the audio is served from a different origin than the website, this is considered a cross origin request.

In order to allow sending the credentials along with such a request, the audio element has a crossorigin attribute, see

[https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin)

**Describe the solution you'd like**


This PR attempts to allow setting this attribute on the `HTML5AudioPlayer` class.

**Describe alternatives you've considered**

Another valid option would be a constructer that accepts an `AudioElement`, such that the attribute can be set before passing it to just_audio.
The other option would be to expose the `_audioElement` with a getter.

**Additional context**

Given the current encapsulation, the `_audioElement` cannot be accessed, if we had a getter around it the following test could be added to the PR

```dart
import 'package:test/test.dart';
import 'package:just_audio_web/just_audio_web.dart';

void main() {
  group('Html5AudioPlayer', () {
    late Html5AudioPlayer player;

    setUp(() {
      player = Html5AudioPlayer(id: 'test_player');
    });

    test('should set anonymous', () {
      final request =
          SetCrossOriginRequest(crossOrigin: CrossOriginMessage.anonymous);
      player.setCrossOrigin(request);
      expect(player.audioElement.attributes['crossOrigin'], 'anonymous');
    });

    test('should set use credentials', () {
      final request =
          SetCrossOriginRequest(crossOrigin: CrossOriginMessage.useCredentials);
      player.setCrossOrigin(request);
      expect(player.audioElement.attributes['crossOrigin'], 'use-credentials');
    });
  });
}
```
