### PR TITLE
added refresh token mechanism

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -2360,7 +2360,6 @@ abstract class UriAudioSource extends IndexedAudioSource {
         player._useProxyForRequestHeaders &&
         (headers != null || player._userAgent != null)) {
       await player._proxy.ensureRunning();
-      print('usage1');
       _overrideUri = player._proxy.addUriAudioSource(this);
     }
   }


### PR DESCRIPTION
In our music player app, a client need to have Authorization headers. When I gave ConcatenatingAudioSource, the player was stuck after some time, when the given token is expired. So I decided to add inbuilt mechanism to refresh credentials by adding some optional fields. I am sure that I didn't break any existing features.