### PR TITLE
[just_audio] Ignore acceptEncodingHeader from proxy server

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -3330,10 +3330,15 @@ _ProxyHandler _proxyHandlerForUri(
     String? host;
     try {
       final requestHeaders = <String, String>{};
-      request.headers
-          .forEach((name, value) => requestHeaders[name] = value.join(', '));
+      request.headers.forEach((name, value) {
+        if (name == HttpHeaders.acceptEncodingHeader) return;
+        requestHeaders[name] = value.join(', ');
+      });
       // write supplied headers last (to ensure supplied headers aren't overwritten)
-      headers?.forEach((name, value) => requestHeaders[name] = value);
+      headers?.forEach((name, value) {
+        if (name == HttpHeaders.acceptEncodingHeader) return;
+        requestHeaders[name] = value;
+      });
       final originRequest =
           await _getUrl(client, redirectedUri ?? uri, headers: requestHeaders);
       host = originRequest.headers.value(HttpHeaders.hostHeader);


### PR DESCRIPTION
# Ignore accept-encoding Header

If the origin response has the `accept-encoding` HTTP header with `useProxyForRequestHeaders: true`, just ignore it.

Because the default HttpServer does not compress responses with GZIP, but the header has `accept-encoding`, the native encoder throws an error.

Another approach is to add the `autoCompress: true` option, but I'm not sure it covers all cases.

## References
- maybe relatated #881 ?
- https://api.dart.dev/stable/3.4.4/dart-io/HttpServer/autoCompress.html