### PR TITLE
Support package:web v1.0.0

### DIFF
--- a/just_audio/CHANGELOG.md
+++ b/just_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.41
+
+* Bump package:web version to `>=0.5.1 <2.0.0`(@ali2236) 
+
 ## 0.9.40
 
 * Fix JDK 21 compile error.

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and concatenate any sound from any source (asset/file/URL/stream) in a variety of audio formats with gapless playback.
-version: 0.9.40
+version: 0.9.41
 repository: https://github.com/ryanheise/just_audio/tree/minor/just_audio
 issue_tracker: https://github.com/ryanheise/just_audio/issues
 topics:
@@ -17,7 +17,7 @@ dependencies:
   just_audio_platform_interface: ^4.3.0
   # just_audio_platform_interface:
   #   path: ../just_audio_platform_interface
-  just_audio_web: ^0.4.11
+  just_audio_web: ^0.4.12
   # just_audio_web:
   #   path: ../just_audio_web
   audio_session: ^0.1.14

--- a/just_audio_web/CHANGELOG.md
+++ b/just_audio_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.12
+
+* Bump package:web version to `>=0.5.1 <2.0.0`(@ali2236)
+
 ## 0.4.11
 
 * Bump package:web upper bound to <0.6.0

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  web: '>=0.3.0 <0.6.0'
+  web: '>=0.3.0 <2.0.0'
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: just_audio_web
 description: Web platform implementation of just_audio. This implementation is endorsed and therefore doesn't require a direct dependency.
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_web
-version: 0.4.11
+version: 0.4.12
 
 flutter:
   plugin:

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  web: '>=0.3.0 <2.0.0'
+  web: '>=0.5.1 <2.0.0'
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
Most newer versions of packages use `web: ^1.0.0` and because `just_audio_web` depends on `web: >=0.3.0 <0.6.0` it is incompatible and prevents using newer versions of packages.

**Whats the difference between web 0.5.1 & web 1.0.0?**
No difference. the web API is now stable to use.

**What is Changed?**
1. web version bumped to `>=0.3.0 <2.0.0`
2. just_audio and just_audio_web versions bumped

Releted issues: #1311 