### PR TITLE
Fix latest `dart2js` and `dart2wasm` failing to compile due to invalid method signatures detected (#1326)

### DIFF
--- a/just_audio_web/CHANGELOG.md
+++ b/just_audio_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.13
+
+* Fix latest `dart2js` and `dart2wasm` failing to compile due to invalid method signatures detected (@sleepysquash).
+
 ## 0.4.12
 
 * Bump package:web version to `>=0.5.1 <2.0.0` (@ali2236)

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -114,50 +114,50 @@ class Html5AudioPlayer extends JustAudioPlayer {
   Html5AudioPlayer({required String id}) : super(id: id) {
     _audioElement.addEventListener(
         'durationchange',
-        (event) {
+        (Event event) {
           _durationCompleter?.complete();
           broadcastPlaybackEvent();
         }.toJS);
     _audioElement.addEventListener(
         'error',
-        (event) {
+        (Event event) {
           _durationCompleter?.completeError(_audioElement.error!);
         }.toJS);
     _audioElement.addEventListener(
         'ended',
-        (event) async {
+        (Event event) {
           _currentAudioSourcePlayer?.complete();
         }.toJS);
     _audioElement.addEventListener(
         'timeupdate',
-        (event) {
+        (Event event) {
           _currentAudioSourcePlayer
               ?.timeUpdated(_audioElement.currentTime.toDouble());
         }.toJS);
     _audioElement.addEventListener(
         'loadstart',
-        (event) {
+        (Event event) {
           transition(ProcessingStateMessage.buffering);
         }.toJS);
     _audioElement.addEventListener(
         'waiting',
-        (event) {
+        (Event event) {
           transition(ProcessingStateMessage.buffering);
         }.toJS);
     _audioElement.addEventListener(
         'stalled',
-        (event) {
+        (Event event) {
           transition(ProcessingStateMessage.buffering);
         }.toJS);
     _audioElement.addEventListener(
         'canplaythrough',
-        (event) {
+        (Event event) {
           _audioElement.playbackRate = _speed;
           transition(ProcessingStateMessage.ready);
         }.toJS);
     _audioElement.addEventListener(
         'progress',
-        (event) {
+        (Event event) {
           broadcastPlaybackEvent();
         }.toJS);
   }

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: just_audio_web
 description: Web platform implementation of just_audio. This implementation is endorsed and therefore doesn't require a direct dependency.
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_web
-version: 0.4.12
+version: 0.4.13
 
 flutter:
   plugin:


### PR DESCRIPTION
This PR fixes #1326 (`just_audio_web` issue with latest `dart2js` and `dart2wasm` compilers) by adding more strict type signature to the functions. Dart incorrectly decides that `(event)` is a `dynamic` type, thus failing to compile. Refactoring that to `(Event event)` fixes the issue.

If there's anything else I can or should do, please, let me know!