### PR TITLE
feat: Add setDeviceId method on web

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1529,8 +1529,8 @@ class AudioPlayer {
   }
 
   /// Sets a specific device output id, null for default
-  void setDeviceId(String? id) {
-    _platform.setDeviceId(id);
+  void setDeviceId(String? id) async {
+    (await _platform).setDeviceId(id);
   }
 
   /// Dispose of the given platform.

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1529,8 +1529,8 @@ class AudioPlayer {
   }
 
   /// Sets a specific device output id, null for default
-  void setDeviceId(String? id) async {
-    (await _platform).setDeviceId(id);
+  Future<void> setDeviceId(String? id) async {
+    await (await _platform).setDeviceId(id);
   }
 
   /// Dispose of the given platform.

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1528,6 +1528,11 @@ class AudioPlayer {
     return durationCompleter.future;
   }
 
+  /// Sets a specific device output id, null for default
+  void setDeviceId(String? id) {
+    _platform.setDeviceId(id);
+  }
+
   /// Dispose of the given platform.
   Future<void> _disposePlatform(AudioPlayerPlatform platform) async {
     if (platform is _IdleAudioPlayer) {

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -3,6 +3,7 @@ description: A feature-rich audio player for Flutter. Loop, clip and concatenate
 version: 0.9.42
 repository: https://github.com/ryanheise/just_audio/tree/minor/just_audio
 issue_tracker: https://github.com/ryanheise/just_audio/issues
+publish_to: none
 topics:
   - audio
   - sound
@@ -14,7 +15,7 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-   just_audio_platform_interface:
+  just_audio_platform_interface:
      path: ../just_audio_platform_interface
   just_audio_web:
      path: ../just_audio_web

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -14,12 +14,10 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  just_audio_platform_interface: ^4.3.0
-  # just_audio_platform_interface:
-  #   path: ../just_audio_platform_interface
-  just_audio_web: ^0.4.11
-  # just_audio_web:
-  #   path: ../just_audio_web
+   just_audio_platform_interface:
+     path: ../just_audio_platform_interface
+  just_audio_web:
+     path: ../just_audio_web
   audio_session: ^0.1.14
   rxdart: '>=0.26.0 <0.29.0'
   path: ^1.8.0

--- a/just_audio_platform_interface/lib/just_audio_platform_interface.dart
+++ b/just_audio_platform_interface/lib/just_audio_platform_interface.dart
@@ -76,6 +76,11 @@ abstract class AudioPlayerPlatform {
   Stream<PlayerDataMessage> get playerDataMessageStream =>
       const Stream<PlayerDataMessage>.empty();
 
+  /// Sets a specific device output id, null for default
+  void setDeviceId(String? deviceId) {
+    throw UnimplementedError("setDeviceId() has not been implemented.");
+  }
+
   /// Loads an audio source.
   Future<LoadResponse> load(LoadRequest request) {
     throw UnimplementedError("load() has not been implemented.");

--- a/just_audio_platform_interface/lib/just_audio_platform_interface.dart
+++ b/just_audio_platform_interface/lib/just_audio_platform_interface.dart
@@ -77,7 +77,7 @@ abstract class AudioPlayerPlatform {
       const Stream<PlayerDataMessage>.empty();
 
   /// Sets a specific device output id, null for default
-  void setDeviceId(String? deviceId) {
+  Future<void> setDeviceId(String? deviceId) {
     throw UnimplementedError("setDeviceId() has not been implemented.");
   }
 

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -181,7 +181,7 @@ class Html5AudioPlayer extends JustAudioPlayer {
 
   /// Sets a specific device output id, null for default
   Future<void> setDeviceId(String? deviceId) async {
-    await _audioElement.setSinkId(deviceId ?? '');
+    await _audioElement.setSinkId(deviceId ?? '').toDart;
   }
 
   /// Called when playback reaches the end of an item.

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -179,6 +179,11 @@ class Html5AudioPlayer extends JustAudioPlayer {
     return orderInv;
   }
 
+  /// Sets a specific device output id, null for default
+  Future<void> setDeviceId(String? deviceId) async {
+    _audioElement.setSinkId(deviceId);
+  }
+
   /// Called when playback reaches the end of an item.
   Future<void> onEnded() async {
     if (_loopMode == LoopModeMessage.one) {

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -181,7 +181,7 @@ class Html5AudioPlayer extends JustAudioPlayer {
 
   /// Sets a specific device output id, null for default
   Future<void> setDeviceId(String? deviceId) async {
-    _audioElement.setSinkId(deviceId ?? '');
+    await _audioElement.setSinkId(deviceId ?? '');
   }
 
   /// Called when playback reaches the end of an item.

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -181,7 +181,7 @@ class Html5AudioPlayer extends JustAudioPlayer {
 
   /// Sets a specific device output id, null for default
   Future<void> setDeviceId(String? deviceId) async {
-    _audioElement.setSinkId(deviceId);
+    _audioElement.setSinkId(deviceId ?? '');
   }
 
   /// Called when playback reaches the end of an item.

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -2,6 +2,7 @@ name: just_audio_web
 description: Web platform implementation of just_audio. This implementation is endorsed and therefore doesn't require a direct dependency.
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_web
 version: 0.4.13
+publish_to: none
 
 flutter:
   plugin:
@@ -11,9 +12,8 @@ flutter:
         fileName: just_audio_web.dart
 
 dependencies:
-  just_audio_platform_interface: ^4.3.0
-  # just_audio_platform_interface:
-  #   path: ../just_audio_platform_interface
+  just_audio_platform_interface:
+    path: ../just_audio_platform_interface
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION
Added setDeviceId method, so the output speaker (HTML5AudioElement sink ID) can be set -- so developer can select which device to play sound instead of default