### PR TITLE
Add timeout option to uri requests

### DIFF
--- a/just_audio/CHANGELOG.md
+++ b/just_audio/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.47
+
+* Add timeoutMillis parameter to Uri/LockCaching/Stream AudioSources (@ctedgar).
+    * Android platform implementation completed
+
 ## 0.9.46
 
 * Fix SwiftPM support on macOS.

--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
@@ -622,20 +622,20 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
         String id = (String)map.get("id");
         switch ((String)map.get("type")) {
         case "progressive":
-            return new ProgressiveMediaSource.Factory(buildDataSourceFactory(mapGet(map, "headers")), buildExtractorsFactory(mapGet(map, "options")))
+            return new ProgressiveMediaSource.Factory(buildDataSourceFactory(mapGet(map, "headers"), mapGet(map, "timeoutMillis")), buildExtractorsFactory(mapGet(map, "options")))
                     .createMediaSource(new MediaItem.Builder()
                             .setUri(Uri.parse((String)map.get("uri")))
                             .setTag(id)
                             .build());
         case "dash":
-            return new DashMediaSource.Factory(buildDataSourceFactory(mapGet(map, "headers")))
+            return new DashMediaSource.Factory(buildDataSourceFactory(mapGet(map, "headers"), mapGet(map, "timeoutMillis")))
                     .createMediaSource(new MediaItem.Builder()
                             .setUri(Uri.parse((String)map.get("uri")))
                             .setMimeType(MimeTypes.APPLICATION_MPD)
                             .setTag(id)
                             .build());
         case "hls":
-            return new HlsMediaSource.Factory(buildDataSourceFactory(mapGet(map, "headers")))
+            return new HlsMediaSource.Factory(buildDataSourceFactory(mapGet(map, "headers"), mapGet(map, "timeoutMillis")))
                     .createMediaSource(new MediaItem.Builder()
                             .setUri(Uri.parse((String)map.get("uri")))
                             .setMimeType(MimeTypes.APPLICATION_M3U8)
@@ -716,7 +716,7 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
         audioEffectsMap.clear();
     }
 
-    private DataSource.Factory buildDataSourceFactory(Map<?, ?> headers) {
+    private DataSource.Factory buildDataSourceFactory(Map<?, ?> headers, Integer timeoutMillis) {
         final Map<String, String> stringHeaders = castToStringMap(headers);
         String userAgent = null;
         if (stringHeaders != null) {
@@ -733,6 +733,11 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
             .setAllowCrossProtocolRedirects(true);
         if (stringHeaders != null && stringHeaders.size() > 0) {
             httpDataSourceFactory.setDefaultRequestProperties(stringHeaders);
+        }
+        //Default for both timeout setting is 8 seconds, so using timeoutMillis to control both
+        if(timeoutMillis!=null){
+            httpDataSourceFactory.setConnectTimeoutMs(timeoutMillis);
+            httpDataSourceFactory.setReadTimeoutMs(timeoutMillis);
         }
         return new DefaultDataSource.Factory(context, httpDataSourceFactory);
     }

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -685,7 +685,7 @@ class AudioPlayer {
   /// This is equivalent to:
   ///
   /// ```
-  /// setAudioSource(AudioSource.uri(Uri.parse(url), headers: headers, tag: tag),
+  /// setAudioSource(AudioSource.uri(Uri.parse(url), headers: headers, timeoutMillis: timeoutMillis, tag: tag),
   ///     initialPosition: Duration.zero, preload: true);
   /// ```
   ///
@@ -693,12 +693,13 @@ class AudioPlayer {
   Future<Duration?> setUrl(
     String url, {
     Map<String, String>? headers,
+    int? timeoutMillis,
     Duration? initialPosition,
     bool preload = true,
     dynamic tag,
   }) =>
       setAudioSource(
-          AudioSource.uri(Uri.parse(url), headers: headers, tag: tag),
+          AudioSource.uri(Uri.parse(url), headers: headers, timeoutMillis: timeoutMillis, tag: tag),
           initialPosition: initialPosition,
           preload: preload);
 
@@ -2116,6 +2117,7 @@ class _ProxyHttpServer {
       uri,
       headers: headers,
       userAgent: source._player?._userAgent,
+      timeoutMillis: source.timeoutMillis
     );
     return uri.replace(
       scheme: 'http',
@@ -2253,17 +2255,20 @@ abstract class AudioSource {
   /// provided by that package. If you wish to have more control over the tag
   /// for background audio purposes, consider using the plugin audio_service
   /// instead of just_audio_background.
+  ///
+  /// [timeoutMillis] can be used to adjust http connection timeout settings
+  /// (currently only supported for Android)
   static UriAudioSource uri(Uri uri,
-      {Map<String, String>? headers, dynamic tag}) {
+      {Map<String, String>? headers, int? timeoutMillis, dynamic tag}) {
     bool hasExtension(Uri uri, String extension) =>
         uri.path.toLowerCase().endsWith('.$extension') ||
         uri.fragment.toLowerCase().endsWith('.$extension');
     if (hasExtension(uri, 'mpd')) {
-      return DashAudioSource(uri, headers: headers, tag: tag);
+      return DashAudioSource(uri, headers: headers, timeoutMillis: timeoutMillis, tag: tag);
     } else if (hasExtension(uri, 'm3u8')) {
-      return HlsAudioSource(uri, headers: headers, tag: tag);
+      return HlsAudioSource(uri, headers: headers, timeoutMillis: timeoutMillis, tag: tag);
     } else {
-      return ProgressiveAudioSource(uri, headers: headers, tag: tag);
+      return ProgressiveAudioSource(uri, headers: headers, timeoutMillis: timeoutMillis, tag: tag);
     }
   }
 
@@ -2350,9 +2355,10 @@ abstract class IndexedAudioSource extends AudioSource {
 abstract class UriAudioSource extends IndexedAudioSource {
   final Uri uri;
   final Map<String, String>? headers;
+  final int? timeoutMillis;
   Uri? _overrideUri;
 
-  UriAudioSource(this.uri, {this.headers, dynamic tag, Duration? duration})
+  UriAudioSource(this.uri, {this.headers, this.timeoutMillis, dynamic tag, Duration? duration})
       : super(tag: tag, duration: duration);
 
   /// If [uri] points to an asset, this gives us [_overrideUri] which is the URI
@@ -2444,12 +2450,16 @@ abstract class UriAudioSource extends IndexedAudioSource {
 ///
 /// If headers are set, just_audio will create a cleartext local HTTP proxy on
 /// your device to forward HTTP requests with headers included.
+///
+/// [timeoutMillis] can be used to adjust http connection timeout settings
+/// (currently only supported for Android)
 class ProgressiveAudioSource extends UriAudioSource {
   final ProgressiveAudioSourceOptions? options;
 
   ProgressiveAudioSource(
     super.uri, {
     super.headers,
+    super.timeoutMillis,
     super.tag,
     super.duration,
     this.options,
@@ -2460,6 +2470,7 @@ class ProgressiveAudioSource extends UriAudioSource {
         id: _id,
         uri: _effectiveUri.toString(),
         headers: _mergedHeaders,
+        timeoutMillis: timeoutMillis,
         tag: tag,
         options: options?._toMessage(),
       );
@@ -2479,16 +2490,20 @@ class ProgressiveAudioSource extends UriAudioSource {
 ///
 /// If headers are set, just_audio will create a cleartext local HTTP proxy on
 /// your device to forward HTTP requests with headers included.
+///
+/// [timeoutMillis] can be used to adjust http connection timeout settings
+/// (currently only supported for Android)
 class DashAudioSource extends UriAudioSource {
   DashAudioSource(Uri uri,
-      {Map<String, String>? headers, dynamic tag, Duration? duration})
-      : super(uri, headers: headers, tag: tag, duration: duration);
+      {Map<String, String>? headers, int? timeoutMillis, dynamic tag, Duration? duration})
+      : super(uri, headers: headers, timeoutMillis: timeoutMillis, tag: tag, duration: duration);
 
   @override
   AudioSourceMessage _toMessage() => DashAudioSourceMessage(
         id: _id,
         uri: _effectiveUri.toString(),
         headers: _mergedHeaders,
+        timeoutMillis: timeoutMillis,
         tag: tag,
       );
 }
@@ -2506,16 +2521,20 @@ class DashAudioSource extends UriAudioSource {
 ///
 /// If headers are set, just_audio will create a cleartext local HTTP proxy on
 /// your device to forward HTTP requests with headers included.
+///
+/// [timeoutMillis] can be used to adjust http connection timeout settings
+/// (currently only supported for Android)
 class HlsAudioSource extends UriAudioSource {
   HlsAudioSource(Uri uri,
-      {Map<String, String>? headers, dynamic tag, Duration? duration})
-      : super(uri, headers: headers, tag: tag, duration: duration);
+      {Map<String, String>? headers, int? timeoutMillis, dynamic tag, Duration? duration})
+      : super(uri, headers: headers, timeoutMillis: timeoutMillis, tag: tag, duration: duration);
 
   @override
   AudioSourceMessage _toMessage() => HlsAudioSourceMessage(
         id: _id,
         uri: _effectiveUri.toString(),
         headers: _mergedHeaders,
+        timeoutMillis: timeoutMillis,
         tag: tag,
       );
 }
@@ -2836,7 +2855,8 @@ Uri _encodeDataUrl(String base64Data, String mimeType) =>
 @experimental
 abstract class StreamAudioSource extends IndexedAudioSource {
   Uri? _uri;
-  StreamAudioSource({dynamic tag}) : super(tag: tag);
+  int? timeoutMillis;
+  StreamAudioSource({this.timeoutMillis, dynamic tag}) : super(tag: tag);
 
   @override
   Future<void> _setup(AudioPlayer player) async {
@@ -2860,7 +2880,7 @@ abstract class StreamAudioSource extends IndexedAudioSource {
 
   @override
   AudioSourceMessage _toMessage() => ProgressiveAudioSourceMessage(
-      id: _id, uri: _uri.toString(), headers: null, tag: tag);
+      id: _id, uri: _uri.toString(), headers: null, timeoutMillis: timeoutMillis, tag: tag);
 }
 
 /// The response for a [StreamAudioSource]. This API is experimental.
@@ -2924,11 +2944,12 @@ class LockCachingAudioSource extends StreamAudioSource {
   LockCachingAudioSource(
     this.uri, {
     this.headers,
+    int? timeoutMillis,
     File? cacheFile,
     dynamic tag,
   })  : cacheFile =
             cacheFile != null ? Future.value(cacheFile) : _getCacheFile(uri),
-        super(tag: tag) {
+        super(tag: tag, timeoutMillis: timeoutMillis) {
     _init();
   }
 
@@ -3012,7 +3033,7 @@ class LockCachingAudioSource extends StreamAudioSource {
     File getEffectiveCacheFile() =>
         partialCacheFile.existsSync() ? partialCacheFile : cacheFile;
 
-    final httpClient = _createHttpClient(userAgent: _player?._userAgent);
+    final httpClient = _createHttpClient(userAgent: _player?._userAgent, timeoutMillis: timeoutMillis);
     final httpRequest = await _getUrl(httpClient, uri, headers: headers);
     final response = await httpRequest.close();
     if (response.statusCode != 200) {
@@ -3127,7 +3148,7 @@ class LockCachingAudioSource extends StreamAudioSource {
         _requests.remove(request);
         final start = request.start!;
         final end = request.end ?? sourceLength;
-        final httpClient = _createHttpClient(userAgent: _player?._userAgent);
+        final httpClient = _createHttpClient(userAgent: _player?._userAgent, timeoutMillis: timeoutMillis);
 
         final rangeRequest = _HttpRangeRequest(start, end);
         _getUrl(httpClient, uri, headers: {
@@ -3352,11 +3373,12 @@ _ProxyHandler _proxyHandlerForUri(
   Uri uri, {
   Map<String, String>? headers,
   String? userAgent,
+  int? timeoutMillis,
 }) {
   // Keep redirected [Uri] to speed-up requests
   Uri? redirectedUri;
   Future<void> handler(_ProxyHttpServer server, HttpRequest request) async {
-    final client = _createHttpClient(userAgent: userAgent);
+    final client = _createHttpClient(userAgent: userAgent, timeoutMillis: timeoutMillis);
     // Try to make normal request
     String? host;
     try {
@@ -4072,10 +4094,15 @@ Future<HttpClientRequest> _getUrl(HttpClient client, Uri uri,
   return request;
 }
 
-HttpClient _createHttpClient({String? userAgent}) {
+HttpClient _createHttpClient({String? userAgent, int? timeoutMillis}) {
   final client = HttpClient();
   if (userAgent != null) {
     client.userAgent = userAgent;
+  }
+  if (timeoutMillis!=null){
+    var connectivityTimeouts = Duration(milliseconds: timeoutMillis);
+    client.idleTimeout = connectivityTimeouts;
+    client.connectionTimeout = connectivityTimeouts;
   }
   return client;
 }

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and concatenate any sound from any source (asset/file/URL/stream) in a variety of audio formats with gapless playback.
-version: 0.9.46
+version: 0.9.47
 repository: https://github.com/ryanheise/just_audio/tree/minor/just_audio
 issue_tracker: https://github.com/ryanheise/just_audio/issues
 topics:
@@ -14,7 +14,7 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  just_audio_platform_interface: ^4.4.0
+  just_audio_platform_interface: ^4.4.1
   # just_audio_platform_interface:
   #   path: ../just_audio_platform_interface
   just_audio_web: ^0.4.14

--- a/just_audio/test/just_audio_test.dart
+++ b/just_audio/test/just_audio_test.dart
@@ -190,6 +190,20 @@ void runTests() {
       exception = e;
     }
     expect(exception != null, equals(true));
+    try {
+      await player.setUrl('https://foo.foo/timeout.mp3');
+      exception = null;
+    } catch (e) {
+      exception = e;
+    }
+    expect(exception != null, equals(true));
+    try {
+      await player.setUrl('https://foo.foo/timeout.mp3', timeoutMillis: 11);
+      exception = null;
+    } catch (e) {
+      exception = e;
+    }
+    expect(exception == null, equals(true));
     await player.dispose();
   });
 
@@ -1563,6 +1577,10 @@ class MockAudioPlayer extends AudioPlayerPlatform {
             code: '404', message: 'Not found: ${audioSource.uri}');
       } else if (uri.path.contains('error')) {
         throw PlatformException(code: 'error', message: 'Unknown error');
+      } else if (audioSource.uri.contains('timeout')){
+        if ((audioSource.timeoutMillis ?? 0) < 10) {
+          throw PlatformException(code: 'timeout', message: 'Timed out (because timeoutMillis setting is less than 10)');
+        }
       }
       _duration = audioSourceDuration;
     } else if (audioSource is ClippingAudioSourceMessage) {

--- a/just_audio_platform_interface/CHANGELOG.md
+++ b/just_audio_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.1
+
+* Add timeoutMillis to UriAudioSourceMessage (@ctedgar).
+
 ## 4.4.0
 
 * Add setWebSinkId for web (@dganzella).

--- a/just_audio_platform_interface/lib/just_audio_platform_interface.dart
+++ b/just_audio_platform_interface/lib/just_audio_platform_interface.dart
@@ -1122,11 +1122,13 @@ abstract class IndexedAudioSourceMessage extends AudioSourceMessage {
 abstract class UriAudioSourceMessage extends IndexedAudioSourceMessage {
   final String uri;
   final Map<String, String>? headers;
+  final int? timeoutMillis;
 
   UriAudioSourceMessage({
     required super.id,
     required this.uri,
     this.headers,
+    this.timeoutMillis,
     super.tag,
   });
 }
@@ -1140,6 +1142,7 @@ class ProgressiveAudioSourceMessage extends UriAudioSourceMessage {
     required super.id,
     required super.uri,
     super.headers,
+    super.timeoutMillis,
     super.tag,
     this.options,
   });
@@ -1150,6 +1153,7 @@ class ProgressiveAudioSourceMessage extends UriAudioSourceMessage {
         'id': id,
         'uri': uri,
         'headers': headers,
+        'timeoutMillis': timeoutMillis,
         'options': options?.toMap(),
       };
 }
@@ -1161,6 +1165,7 @@ class DashAudioSourceMessage extends UriAudioSourceMessage {
     required super.id,
     required super.uri,
     super.headers,
+    super.timeoutMillis,
     super.tag,
   });
 
@@ -1170,6 +1175,7 @@ class DashAudioSourceMessage extends UriAudioSourceMessage {
         'id': id,
         'uri': uri,
         'headers': headers,
+        'timeoutMillis': timeoutMillis,
       };
 }
 
@@ -1180,6 +1186,7 @@ class HlsAudioSourceMessage extends UriAudioSourceMessage {
     required super.id,
     required super.uri,
     super.headers,
+    super.timeoutMillis,
     super.tag,
   });
 
@@ -1189,6 +1196,7 @@ class HlsAudioSourceMessage extends UriAudioSourceMessage {
         'id': id,
         'uri': uri,
         'headers': headers,
+        'timeoutMillis': timeoutMillis,
       };
 }
 

--- a/just_audio_platform_interface/pubspec.yaml
+++ b/just_audio_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the just_audio plugin. Different pl
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.4.0
+version: 4.4.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Hi @ryanheise,

This is a pull request to address #1119, it includes the following changes:

1. just_audio_platform_interface: Updated the implementations of UriAudioSourceMessage to include the optional timeoutMillis parameter.
2. just_audio: 
-  Added timeout parameters to UriAudioSource and StreamAudioSource implementations.
-  Updated AudioPlayer.java to expect the optional timeout parameter and respect it if set. 
-  Added a test case under _'load error'_ to simulate the timeout error and to also validate the plumbing of the new parameter. (i.e. assert that the timeout property is making it down to the platform message)

I realize there may be a need to implement the same functionality for all other platforms. I've just carried out the changes for Android as it's what I could test comfortably.

I added change notes and bumped the versions both just_audio and just_audio_platform_interface though I suppose just_audio_platform_interface would need to be published first followed by just_audio, if these changes are accepted ofcourse.  

Note for local testing: Update just_audio_platform_interface/just_audio_web dependency in just_audio pubspec to point to local folder

Regards,
Cris