### PR TITLE
feat(LockCachingAudioSource): add network error handling

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -3598,41 +3598,74 @@ class LockCachingAudioSource extends StreamAudioSource {
 
   @override
   Future<StreamAudioResponse> request([int? start, int? end]) async {
-    final cacheFile = await this.cacheFile;
-    if (cacheFile.existsSync()) {
-      final sourceLength = cacheFile.lengthSync();
-      return StreamAudioResponse(
-        rangeRequestsSupported: true,
-        sourceLength: start != null ? sourceLength : null,
-        contentLength: (end ?? sourceLength) - (start ?? 0),
-        offset: start,
-        contentType: await _readCachedMimeType(),
-        stream: cacheFile.openRead(start, end).asBroadcastStream(),
-      );
-    }
-    final byteRangeRequest = _StreamingByteRangeRequest(start, end);
-    _requests.add(byteRangeRequest);
-    _response ??=
-        _fetch().catchError((dynamic error, StackTrace? stackTrace) async {
-      // So that we can restart later
-      _response = null;
-      // Cancel any pending request
-      for (final req in _requests) {
-        req.fail(error, stackTrace);
+    try {
+      final cacheFile = await this.cacheFile;
+
+      if (cacheFile.existsSync()) {
+        final sourceLength = cacheFile.lengthSync();
+        return StreamAudioResponse(
+          rangeRequestsSupported: true,
+          sourceLength: start != null ? sourceLength : null,
+          contentLength: (end ?? sourceLength) - (start ?? 0),
+          offset: start,
+          contentType: await _readCachedMimeType(),
+          stream: cacheFile.openRead(start, end).asBroadcastStream(),
+        );
       }
-      return Future<HttpClientResponse>.error(error as Object, stackTrace);
-    });
-    return byteRangeRequest.future.then((response) {
-      response.stream.listen((event) {}, onError: (Object e, StackTrace st) {
-        // So that we can restart later
-        _response = null;
-        // Cancel any pending request
-        for (final req in _requests) {
-          req.fail(e, st);
-        }
+
+      final byteRangeRequest = _StreamingByteRangeRequest(start, end);
+      _requests.add(byteRangeRequest);
+
+      // Start fetching if not already in progress
+      _response ??= _fetch().catchError((dynamic error, StackTrace? stackTrace) async {
+        _handleFetchError(error, stackTrace);
+        return Future<HttpClientResponse>.error(error as Object, stackTrace);
       });
-      return response;
-    });
+
+      // Await the byte range request response and handle stream errors
+      return byteRangeRequest.future.then((response) {
+        response.stream.listen((event) {}, onError: (Object e, StackTrace st) {
+          _handleFetchError(e, st);
+        });
+        return response;
+      });
+    } catch (e, stackTrace) {
+      return _handleFetchError(e, stackTrace);
+    }
+  }
+
+  Future<StreamAudioResponse> _handleFetchError(dynamic error, StackTrace? stackTrace) async {
+    _response = null; // Reset response so that future attempts can retry
+
+    // Cancel any pending requests
+    for (final req in _requests) {
+      req.fail(error, stackTrace);
+    }
+    _requests.clear();
+
+    // Log the error for debugging
+    print("Error in LockCachingAudioSource.request: $error\n$stackTrace");
+
+    // Handle specific error types
+    if (error is SocketException) {
+      print("Network error: No internet connection or server unreachable.");
+    } else if (error is HttpException) {
+      print("HTTP error: ${error.message}");
+    } else if (error is TimeoutException) {
+      print("Timeout error: Request took too long to respond.");
+    } else {
+      print("Unexpected error: $error");
+    }
+
+    // Return a 503 Service Unavailable response
+    return StreamAudioResponse(
+      rangeRequestsSupported: false,
+      sourceLength: null,
+      contentLength: null,
+      offset: null,
+      contentType: 'audio/mpeg',
+      stream: Stream<List<int>>.error(error as Object, stackTrace),
+    );
   }
 }
 

--- a/just_audio/test/lock_caching_audio_source_test.dart
+++ b/just_audio/test/lock_caching_audio_source_test.dart
@@ -98,7 +98,7 @@ void main() {
 
       try {
         await source.request();
-        fail('Should have thrown');
+        fail('Should not come here');
       } catch (e) {
         expect(e, isA<SocketException>());
       }

--- a/just_audio/test/lock_caching_audio_source_test.dart
+++ b/just_audio/test/lock_caching_audio_source_test.dart
@@ -12,7 +12,10 @@ File buildCache(String fileName, Directory tempDir) {
   return File(cacheFilePath);
 }
 
-void mockHttpClient({List<int> responseData = const [], Object? error}) {
+void mockHttpClient({
+  List<int> responseData = const [],
+  Map<int, Object> error = const {},
+}) {
   final httpClient = FakeHttpClient(responseData: responseData, error: error);
   HttpOverrides.global = FakeHttpOverrides(httpClient);
 }
@@ -86,22 +89,59 @@ void main() {
       );
     });
 
-    test('Getting a timeout error from the client it finishes', () async {
-      mockHttpClient(error: const SocketException('any'));
+    group('retry on error', (){
+      test('Getting a timeout error retries to fetch the complete content', () async {
+        final responseData = List<int>.generate(1024, (i) => i % 256);
+        mockHttpClient(
+          responseData: responseData,
+          error: {
+            0: const SocketException('any'),
+          },
+        );
 
-      final cacheFile = buildCache('timeout_test.mp3', cacheDir);
-      final source = LockCachingAudioSource(
-        Uri.parse('https://any.com/timeout_test.mp3'),
-        cacheFile: cacheFile,
-        retryTimes: 0,
-      );
+        final cacheFile = buildCache('timeout_test.mp3', cacheDir);
+        final source = LockCachingAudioSource(
+          Uri.parse('https://any.com/timeout_test.mp3'),
+          cacheFile: cacheFile,
+          retryTimes: 1,
+          retryDelayMillis: 0,
+        );
 
-      try {
-        await source.request();
-        fail('Should not come here');
-      } catch (e) {
-        expect(e, isA<SocketException>());
-      }
+        final response = await source.request();
+
+        final collected = <int>[];
+        await response.stream.forEach(collected.addAll);
+        expect(collected.length, equals(responseData.length));
+
+        expect(await cacheFile.length(), equals(responseData.length));
+      });
+
+      test('If it gets a timeout after the retry was done fail', () async {
+        final responseData = List<int>.generate(1024, (i) => i % 256);
+        mockHttpClient(
+          responseData: responseData,
+          error: {
+            0: const SocketException('1'),
+            1: const SocketException('2'),
+          },
+        );
+
+        final cacheFile = buildCache('timeout_test.mp3', cacheDir);
+        final source = LockCachingAudioSource(
+          Uri.parse('https://any.com/timeout_test.mp3'),
+          cacheFile: cacheFile,
+          retryTimes: 1,
+          retryDelayMillis: 0,
+        );
+
+        try {
+          await source.request();
+          fail('Should have thrown the exception!');
+        } catch (e) {
+          expect(e, isA<SocketException>());
+          rethrow; // Let the test framework handle the error
+        }
+      });
     });
 
     test('Request returns data from partial file during download', () async {

--- a/just_audio/test/lock_caching_audio_source_test.dart
+++ b/just_audio/test/lock_caching_audio_source_test.dart
@@ -89,61 +89,6 @@ void main() {
       );
     });
 
-    group('retry on error', (){
-      test('Getting a timeout error retries to fetch the complete content', () async {
-        final responseData = List<int>.generate(1024, (i) => i % 256);
-        mockHttpClient(
-          responseData: responseData,
-          error: {
-            0: const SocketException('any'),
-          },
-        );
-
-        final cacheFile = buildCache('timeout_test.mp3', cacheDir);
-        final source = LockCachingAudioSource(
-          Uri.parse('https://any.com/timeout_test.mp3'),
-          cacheFile: cacheFile,
-          retryTimes: 1,
-          retryDelayMillis: 0,
-        );
-
-        final response = await source.request();
-
-        final collected = <int>[];
-        await response.stream.forEach(collected.addAll);
-        expect(collected.length, equals(responseData.length));
-
-        expect(await cacheFile.length(), equals(responseData.length));
-      });
-
-      test('If it gets a timeout after the retry was done fail', () async {
-        final responseData = List<int>.generate(1024, (i) => i % 256);
-        mockHttpClient(
-          responseData: responseData,
-          error: {
-            0: const SocketException('1'),
-            1: const SocketException('2'),
-          },
-        );
-
-        final cacheFile = buildCache('timeout_test.mp3', cacheDir);
-        final source = LockCachingAudioSource(
-          Uri.parse('https://any.com/timeout_test.mp3'),
-          cacheFile: cacheFile,
-          retryTimes: 1,
-          retryDelayMillis: 0,
-        );
-
-        try {
-          await source.request();
-          fail('Should have thrown the exception!');
-        } catch (e) {
-          expect(e, isA<SocketException>());
-          rethrow; // Let the test framework handle the error
-        }
-      });
-    });
-
     test('Request returns data from partial file during download', () async {
       final responseData = List<int>.generate(1024, (i) => i % 256);
       mockHttpClient(responseData: responseData);

--- a/just_audio/test/lock_caching_audio_source_test.dart
+++ b/just_audio/test/lock_caching_audio_source_test.dart
@@ -12,8 +12,8 @@ File buildCache(String fileName, Directory tempDir) {
   return File(cacheFilePath);
 }
 
-void mockHttpClient({List<int> responseData = const []}) {
-  final httpClient = FakeHttpClient(responseData: responseData);
+void mockHttpClient({List<int> responseData = const [], Object? error}) {
+  final httpClient = FakeHttpClient(responseData: responseData, error: error);
   HttpOverrides.global = FakeHttpOverrides(httpClient);
 }
 
@@ -26,12 +26,17 @@ void main() {
 
   setUp(() async {
     cacheDir = await Directory.systemTemp.createTemp('lock_caching_test');
-    print('Cache dir: ${cacheDir.path}');
+
+    // ignore: avoid_print
+    print('Created cache dir: ${cacheDir.path}');
   });
 
   tearDown(() async {
     if (await cacheDir.exists()) {
       await cacheDir.delete(recursive: true);
+
+      // ignore: avoid_print
+      print('Deleted cache dir: ${cacheDir.path}');
     }
   });
 
@@ -81,7 +86,23 @@ void main() {
       );
     });
 
-    test('Getting a timeout error from the client continues', () {});
+    test('Getting a timeout error from the client it finishes', () async {
+      mockHttpClient(error: const SocketException('any'));
+
+      final cacheFile = buildCache('timeout_test.mp3', cacheDir);
+      final source = LockCachingAudioSource(
+        Uri.parse('https://any.com/timeout_test.mp3'),
+        cacheFile: cacheFile,
+        retryTimes: 0,
+      );
+
+      try {
+        await source.request();
+        fail('Should have thrown');
+      } catch (e) {
+        expect(e, isA<SocketException>());
+      }
+    });
 
     test('Request returns data from partial file during download', () async {
       final responseData = List<int>.generate(1024, (i) => i % 256);

--- a/just_audio/test/lock_caching_audio_source_test.dart
+++ b/just_audio/test/lock_caching_audio_source_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:path/path.dart' as p;
+
+import 'test_utils/fake_http.dart';
+
+/// Helper function to create a temporary cache file in the [tempDir].
+File buildCache(String fileName, Directory tempDir) {
+  final cacheFilePath = p.join(tempDir.path, fileName);
+  return File(cacheFilePath);
+}
+
+void mockHttpClient({List<int> responseData = const []}) {
+  final httpClient = FakeHttpClient(responseData: responseData);
+  HttpOverrides.global = FakeHttpOverrides(httpClient);
+}
+
+void main() {
+  late Directory cacheDir;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  setUp(() async {
+    cacheDir = await Directory.systemTemp.createTemp('lock_caching_test');
+    print('Cache dir: ${cacheDir.path}');
+  });
+
+  tearDown(() async {
+    if (await cacheDir.exists()) {
+      await cacheDir.delete(recursive: true);
+    }
+  });
+
+  group('LockCachingAudioSource - Good and edge cases', () {
+    test('Already having a cached file just return it', () async {
+      final responseData = List<int>.generate(1024, (i) => i % 256);
+      mockHttpClient(responseData: responseData);
+      final cacheFile = buildCache('test.mp3', cacheDir);
+      await cacheFile.writeAsString("any content");
+
+      final source = LockCachingAudioSource(
+        Uri.parse('https://any.com/test.mp3'),
+        cacheFile: cacheFile,
+      );
+
+      final response = await source.request();
+
+      expect(
+        response,
+        isA<StreamAudioResponse>()
+            .having((r) => r.contentLength, 'sourceLength', equals(11)),
+      );
+      expect(await cacheFile.exists(), isTrue);
+    });
+
+    test('Byte-range request returns correct content length and offset',
+        () async {
+      final responseData = List<int>.generate(1024, (i) => i % 256);
+      mockHttpClient(responseData: responseData);
+
+      final cacheFile = buildCache('range_test.mp3', cacheDir);
+      final source = LockCachingAudioSource(
+        Uri.parse('https://any.com/range_test.mp3'),
+        cacheFile: cacheFile,
+      );
+
+      final response = await source.request(100, 300);
+      expect(response.contentLength, equals(200));
+
+      final collected = <int>[];
+      await response.stream.forEach(collected.addAll);
+      expect(
+        collected,
+        isA<List<int>>()
+            .having((l) => l, 'length', hasLength(200))
+            .having((l) => l.first, 'first', equals(responseData[100])),
+      );
+    });
+
+    test('Getting a timeout error from the client continues', () {});
+
+    test('Request returns data from partial file during download', () async {
+      final responseData = List<int>.generate(1024, (i) => i % 256);
+      mockHttpClient(responseData: responseData);
+
+      final cacheFile = buildCache('partial.mp3', cacheDir);
+      final source = LockCachingAudioSource(
+        Uri.parse('https://any.com/partial.mp3'),
+        cacheFile: cacheFile,
+      );
+
+      final downloadFuture = source.request();
+
+      final middleLength = responseData.length / 2;
+      final rangeResponse = await source.request(0, middleLength.toInt());
+      final collected = <int>[];
+      await rangeResponse.stream.forEach(collected.addAll);
+      expect(collected.length, equals(middleLength));
+
+      await downloadFuture;
+      expect(await cacheFile.length(), equals(responseData.length));
+    });
+  });
+}

--- a/just_audio/test/test_utils/fake_http.dart
+++ b/just_audio/test/test_utils/fake_http.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+import 'dart:io';
+
+/// A simple concrete implementation of [HttpHeaders] for testing.
+class FakeHttpHeaders implements HttpHeaders {
+  final Map<String, List<String>> _headers = {};
+
+  @override
+  ContentType? get contentType {
+    final header = value(HttpHeaders.contentTypeHeader);
+    if (header == null) return null;
+
+    return ContentType.parse(header);
+  }
+
+  @override
+  void add(
+    String name,
+    Object value, {
+    bool preserveHeaderCase = false,
+  }) {
+    final key = name.toLowerCase();
+    _headers.putIfAbsent(key, () => []).add(value.toString());
+  }
+
+  @override
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {
+    _headers[name.toLowerCase()] = [value.toString()];
+  }
+
+  @override
+  List<String>? operator [](String name) => _headers[name.toLowerCase()];
+
+  @override
+  String? value(String name) {
+    final values = _headers[name.toLowerCase()];
+    if (values == null || values.isEmpty) return null;
+    return values.first;
+  }
+
+  // Stub out all other members.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// A fake HTTP client that implements HttpClient.
+class FakeHttpClient implements HttpClient {
+  final List<int> responseData;
+  final int statusCode;
+  final int contentLength;
+
+  FakeHttpClient({
+    required this.responseData,
+    this.statusCode = 200,
+    int? contentLength,
+  }) : contentLength = contentLength ?? responseData.length;
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) async {
+    return FakeHttpClientRequest(url, responseData, statusCode, contentLength);
+  }
+
+  @override
+  void close({bool force = false}) {
+    // Nothing to close.
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// A fake HTTP client request.
+class FakeHttpClientRequest implements HttpClientRequest {
+  final Uri url;
+  final List<int> fakeData;
+  final int statusCode;
+
+  @override
+  final int contentLength;
+
+  @override
+  int maxRedirects = 5;
+
+  FakeHttpClientRequest(
+      this.url, this.fakeData, this.statusCode, this.contentLength);
+
+  @override
+  Future<HttpClientResponse> close() async {
+    return FakeHttpClientResponse(fakeData, statusCode, contentLength);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// A fake HTTP client response that uses a StreamController to send fakeData
+/// and then closes the stream.
+class FakeHttpClientResponse extends Stream<List<int>>
+    implements HttpClientResponse {
+  final List<int> fakeData;
+  @override
+  final int statusCode;
+  @override
+  final int contentLength;
+
+  FakeHttpClientResponse(this.fakeData, this.statusCode, this.contentLength);
+
+  @override
+  HttpHeaders get headers {
+    final h = FakeHttpHeaders();
+    h.set(HttpHeaders.contentLengthHeader, contentLength);
+    h.set(HttpHeaders.acceptRangesHeader, 'bytes');
+    h.set(HttpHeaders.contentTypeHeader, 'audio/mpeg');
+    return h;
+  }
+
+  @override
+  StreamSubscription<List<int>> listen(void Function(List<int> event)? onData,
+      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+    final controller = StreamController<List<int>>();
+    // Add fakeData and then close the stream.
+    controller.add(fakeData);
+    controller.close();
+    return controller.stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// A Fake HttpOverrides that returns a FakeHttpClient.
+class FakeHttpOverrides extends HttpOverrides {
+  FakeHttpOverrides(this._client);
+
+  final HttpClient _client;
+
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    return _client;
+  }
+}

--- a/just_audio/test/test_utils/fake_http.dart
+++ b/just_audio/test/test_utils/fake_http.dart
@@ -45,18 +45,25 @@ class FakeHttpHeaders implements HttpHeaders {
 
 /// A fake HTTP client that implements HttpClient.
 class FakeHttpClient implements HttpClient {
-  final List<int> responseData;
-  final int statusCode;
-  final int contentLength;
-
   FakeHttpClient({
     required this.responseData,
     this.statusCode = 200,
     int? contentLength,
+    this.error,
   }) : contentLength = contentLength ?? responseData.length;
+
+  final List<int> responseData;
+  final int statusCode;
+  final int contentLength;
+  final Object? error;
 
   @override
   Future<HttpClientRequest> getUrl(Uri url) async {
+    final error = this.error;
+    if (error != null) {
+      return Future.error(error);
+    }
+
     return FakeHttpClientRequest(url, responseData, statusCode, contentLength);
   }
 

--- a/just_audio/test/test_utils/fake_http.dart
+++ b/just_audio/test/test_utils/fake_http.dart
@@ -49,20 +49,23 @@ class FakeHttpClient implements HttpClient {
     required this.responseData,
     this.statusCode = 200,
     int? contentLength,
-    this.error,
+    this.error = const {},
   }) : contentLength = contentLength ?? responseData.length;
 
   final List<int> responseData;
   final int statusCode;
   final int contentLength;
-  final Object? error;
+  final Map<int, Object> error;
+  int requestCount = 0;
 
   @override
   Future<HttpClientRequest> getUrl(Uri url) async {
-    final error = this.error;
+    final error = this.error[requestCount];
+    requestCount++;
     if (error != null) {
       return Future.error(error);
     }
+
 
     return FakeHttpClientRequest(url, responseData, statusCode, contentLength);
   }


### PR DESCRIPTION
Try to fix:
- #1213
- #594

Done:
- Add retry mechanism for _fetch
- Do not throw exceptions on query but return Future with errors so caller could handle them gracefully