### PR TITLE
Prevent cyclic future dependency when disposed during platform loading

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1418,7 +1418,7 @@ class AudioPlayer {
           await _disposePlatform(oldPlatform);
         }
       }
-      if (_disposed) return _platform;
+      if (_disposed) throw StateError('Platform is disposed');
       // During initialisation, we must only use this platform reference in case
       // _platform is updated again during initialisation.
       final platform = active
@@ -1546,6 +1546,9 @@ class AudioPlayer {
     }
 
     _platform = setPlatform();
+    // Ignore errors for the caller of this function, but any attempt on using
+    // the _platform future will still throw any error that is ignored here.
+    _platform.ignore();
     return durationCompleter.future;
   }
 


### PR DESCRIPTION
This fixes the problem described in #1428.

I have also manually verified that if any code attempts to use the `_platform` future in the errored state, it will just throw the `StateError`.