### PR TITLE
Allow audio_session 0.2.0

### DIFF
--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   just_audio_web: ^0.4.14
   # just_audio_web:
   #   path: ../just_audio_web
-  audio_session: ^0.1.24
+  audio_session: ">=0.1.24 <0.3.0"
   rxdart: '>=0.26.0 <0.29.0'
   path: ^1.8.0
   path_provider: ^2.0.0


### PR DESCRIPTION
audio_session 0.2.x does not introduce any breaking changes to the API, but only to the iOS setup. Hence no code changes are required.