### PR TITLE
Fix stop() not broadcasting idle state

### DIFF
--- a/just_audio_background/lib/just_audio_background.dart
+++ b/just_audio_background/lib/just_audio_background.dart
@@ -73,19 +73,11 @@ class JustAudioBackground {
     );
   }
 
-  /// Clear the current device playback.
-  /// On iOS, this has the effect to dismiss the device player.
-  static Future<void> clearPlayback() async {
-    await _audioHandler.stop();
+  /// Ensure the player state is broadcasted to the device.
+  static Future<void> broadcastState() async {
     if (_audioHandler.inner is _PlayerAudioHandler) {
       final playerHandler = _audioHandler.inner as _PlayerAudioHandler;
-      playerHandler._justAudioEvent = playerHandler._justAudioEvent.copyWith(
-        processingState: ProcessingStateMessage.idle,
-      );
-      playerHandler._playing = false;
       playerHandler._broadcastState();
-      playerHandler.updateQueue([]);
-      playerHandler.mediaItem.add(null);
     }
   }
 }

--- a/just_audio_background/lib/just_audio_background.dart
+++ b/just_audio_background/lib/just_audio_background.dart
@@ -72,14 +72,6 @@ class JustAudioBackground {
       androidBrowsableRootExtras: androidBrowsableRootExtras,
     );
   }
-
-  /// Ensure the player state is broadcasted to the device.
-  static Future<void> broadcastState() async {
-    if (_audioHandler.inner is _PlayerAudioHandler) {
-      final playerHandler = _audioHandler.inner as _PlayerAudioHandler;
-      playerHandler._broadcastState();
-    }
-  }
 }
 
 class _JustAudioBackgroundPlugin extends JustAudioPlatform {
@@ -719,12 +711,12 @@ class _PlayerAudioHandler extends BaseAudioHandler
         if (player == null) return;
         _updatePosition();
         customEvent.add(_PlayingEvent(_playing = false));
-        _broadcastState();
-        _playerCompleter = _ValueCompleter<AudioPlayerPlatform>();
-        await _platform.disposePlayer(DisposePlayerRequest(id: player.id));
         _justAudioEvent = _justAudioEvent.copyWith(
           processingState: ProcessingStateMessage.idle,
         );
+        _broadcastState();
+        _playerCompleter = _ValueCompleter<AudioPlayerPlatform>();
+        await _platform.disposePlayer(DisposePlayerRequest(id: player.id));
       });
 
   Duration get currentPosition {

--- a/just_audio_background/lib/just_audio_background.dart
+++ b/just_audio_background/lib/just_audio_background.dart
@@ -72,6 +72,22 @@ class JustAudioBackground {
       androidBrowsableRootExtras: androidBrowsableRootExtras,
     );
   }
+
+  /// Clear the current device playback.
+  /// On iOS, this has the effect to dismiss the device player.
+  static Future<void> clearPlayback() async {
+    await _audioHandler.stop();
+    if (_audioHandler.inner is _PlayerAudioHandler) {
+      final playerHandler = _audioHandler.inner as _PlayerAudioHandler;
+      playerHandler._justAudioEvent = playerHandler._justAudioEvent.copyWith(
+        processingState: ProcessingStateMessage.idle,
+      );
+      playerHandler._playing = false;
+      playerHandler._broadcastState();
+      playerHandler.updateQueue([]);
+      playerHandler.mediaItem.add(null);
+    }
+  }
 }
 
 class _JustAudioBackgroundPlugin extends JustAudioPlatform {


### PR DESCRIPTION
When the audio player is stopped, the device player is not dismissed because idle state is not being broadcasted.