### PR TITLE
Fix player state broadcasting after disposal in _PlayerAudioHandler

### DIFF
--- a/just_audio_background/lib/just_audio_background.dart
+++ b/just_audio_background/lib/just_audio_background.dart
@@ -711,12 +711,12 @@ class _PlayerAudioHandler extends BaseAudioHandler
         if (player == null) return;
         _updatePosition();
         customEvent.add(_PlayingEvent(_playing = false));
-        _broadcastState();
         _playerCompleter = _ValueCompleter<AudioPlayerPlatform>();
         await _platform.disposePlayer(DisposePlayerRequest(id: player.id));
         _justAudioEvent = _justAudioEvent.copyWith(
           processingState: ProcessingStateMessage.idle,
         );
+        _broadcastState();
       });
 
   Duration get currentPosition {


### PR DESCRIPTION
## Issue

In the `just_audio_background` plugin, when the `stop()` method is called in the `_PlayerAudioHandler` class, the processing state is correctly updated to `idle`:

```dart
_justAudioEvent = _justAudioEvent.copyWith(
  processingState: ProcessingStateMessage.idle,
);
```

However, this state change isn't being broadcast to listeners, causing the UI to potentially remain in a stale state even after playback is stopped.

---

## Fix

Add a call to `_broadcastState()` after updating the processing state:

```dart
_justAudioEvent = _justAudioEvent.copyWith(
  processingState: ProcessingStateMessage.idle,
);
_broadcastState(); // Broadcast the updated state to listeners
```

---

## Why This Fix Is Needed

Without broadcasting the state change:

- Clients don't receive notification that playback has stopped
- UI components may continue showing incorrect playback state
- Notifications remain visible and are not removed when playback stops

This fix ensures that:

- All listeners are properly notified when the audio player is stopped
- The actual player state and the UI remain in sync
- **The audio playback notification is correctly removed when `stop()` is called**

---

## Testing

This change has been tested on **Android** and **iOS**, confirming that:

- The UI correctly updates its state when playback is stopped
- **The notification is successfully removed upon calling `stop()`**
