### PR TITLE
Support custom AudioHandler

### DIFF
--- a/just_audio_background/CHANGELOG.md
+++ b/just_audio_background/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1-beta.17
+
+* Support custom AudioHandler.
+
 ## 0.0.1-beta.16
 
 * Support errorCode, errorMessage.

--- a/just_audio_background/lib/just_audio_background.dart
+++ b/just_audio_background/lib/just_audio_background.dart
@@ -49,6 +49,7 @@ class JustAudioBackground {
     Duration rewindInterval = const Duration(seconds: 10),
     bool preloadArtwork = false,
     Map<String, dynamic>? androidBrowsableRootExtras,
+    AudioHandler? handler,
   }) async {
     WidgetsFlutterBinding.ensureInitialized();
     await _JustAudioBackgroundPlugin.setup(
@@ -70,6 +71,7 @@ class JustAudioBackground {
       rewindInterval: rewindInterval,
       preloadArtwork: preloadArtwork,
       androidBrowsableRootExtras: androidBrowsableRootExtras,
+      handler: handler,
     );
   }
 }
@@ -92,11 +94,12 @@ class _JustAudioBackgroundPlugin extends JustAudioPlatform {
     Duration rewindInterval = const Duration(seconds: 10),
     bool preloadArtwork = false,
     Map<String, dynamic>? androidBrowsableRootExtras,
+    AudioHandler? handler,
   }) async {
     _platform = JustAudioPlatform.instance;
     JustAudioPlatform.instance = _JustAudioBackgroundPlugin();
     _audioHandler = await AudioService.init(
-      builder: () => SwitchAudioHandler(BaseAudioHandler()),
+      builder: () => SwitchAudioHandler(handler ?? BaseAudioHandler()),
       config: AudioServiceConfig(
         androidResumeOnClick: androidResumeOnClick,
         androidNotificationChannelId: androidNotificationChannelId,

--- a/just_audio_background/pubspec.yaml
+++ b/just_audio_background/pubspec.yaml
@@ -1,7 +1,7 @@
 name: just_audio_background
 description: An add-on for just_audio that supports background playback and media notifications.
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_background
-version: 0.0.1-beta.16
+version: 0.0.1-beta.17
 topics:
   - audio
   - sound


### PR DESCRIPTION
I am using just_audio_backgound for Android Auto and I need to provide list of `MediaItem`. This is supported by [audio_service](https://pub.dev/packages/audio_service) library already, but there is no possibility to provide custom `AudioHandler` via `just_audio_background`.

In this PR I added `AudioHandler` into `JustAudioBackground.init` method.