### PR TITLE
Include failing url for `LockCachingAudioSource` request exceptions

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -3429,7 +3429,7 @@ class LockCachingAudioSource extends StreamAudioSource {
     final response = await httpRequest.close();
     if (response.statusCode != 200) {
       httpClient.close();
-      throw Exception('HTTP Status Error: ${response.statusCode}');
+      throw Exception('HTTP Status Error: ${response.statusCode}, URL: ${uri}');
     }
     (await _partialCacheFile).createSync(recursive: true);
     // TODO: Should close sink after done, but it throws an error.
@@ -3549,7 +3549,7 @@ class LockCachingAudioSource extends StreamAudioSource {
           final response = await httpRequest.close();
           if (response.statusCode != 206) {
             httpClient.close();
-            throw Exception('HTTP Status Error: ${response.statusCode}');
+            throw Exception('HTTP Status Error: ${response.statusCode}, URL: ${uri}');
           }
           request.complete(StreamAudioResponse(
             rangeRequestsSupported: originSupportsRangeRequests,


### PR DESCRIPTION
This PR enhances the error handling in `LockCachingAudioSource` by including the URL in HTTP error messages. When a non-200/206 status code is encountered, the error message now includes both the status code and the URL that caused the error, making debugging network issues significantly easier.

# Changes
- Added URL information to error messages thrown when HTTP requests fail with non-200 status codes
- Added URL information to error messages thrown when range requests fail with non-206 status codes

# Motivation
When dealing with audio playback issues related to network requests, having both the status code and the URL in the error message provides crucial context for debugging. This is especially helpful in applications that handle multiple audio sources or when troubleshooting API issues.

