### PR TITLE
Bugfix: iOS app termination NSInternalInconsistencyException

### DIFF
--- a/just_audio/CHANGELOG.md
+++ b/just_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.4
+
+* Fix dealloc crash on iOS when app is forcibly terminated.
+
 ## 0.10.3
 
 * Fix pending timers bug in unit tests.

--- a/just_audio/darwin/just_audio/Sources/just_audio/AudioPlayer.m
+++ b/just_audio/darwin/just_audio/Sources/just_audio/AudioPlayer.m
@@ -1338,8 +1338,10 @@
         }];
     }
 }
-
 - (void)dispose:(BOOL)calledFromDealloc {
+    [self dispose:calledFromDealloc terminating:NO];
+}
+- (void)dispose:(BOOL)calledFromDealloc terminating:(BOOL)terminating{
     if (!_player) return;
     if (_processingState != psIdle) {
         [_player pause];
@@ -1381,8 +1383,8 @@
         _player = nil;
     }
     // Untested:
-    [_eventChannel dispose];
-    [_dataEventChannel dispose];
+    [_eventChannel dispose:terminating];
+    [_dataEventChannel dispose:terminating];
     [_methodChannel setMethodCallHandler:nil];
 }
 

--- a/just_audio/darwin/just_audio/Sources/just_audio/BetterEventChannel.m
+++ b/just_audio/darwin/just_audio/Sources/just_audio/BetterEventChannel.m
@@ -30,8 +30,10 @@
     _eventSink(event);
 }
 
-- (void)dispose {
-    if (_eventSink) {
+- (void)dispose:(BOOL)terminating {
+    // If the app is terminating, the FlutterEngine may be deallocated before this and cause:
+    // NSInternalInconsistencyException: 'Sending a message before the FlutterEngine has been run.'
+    if (_eventSink && !terminating) {
         _eventSink(FlutterEndOfEventStream);
     }
     [_eventChannel setStreamHandler:nil];

--- a/just_audio/darwin/just_audio/Sources/just_audio/JustAudioPlugin.m
+++ b/just_audio/darwin/just_audio/Sources/just_audio/JustAudioPlugin.m
@@ -58,7 +58,7 @@
 
 - (void)dealloc {
     for (NSString *playerId in _players) {
-        [_players[playerId] dispose:YES];
+        [_players[playerId] dispose:YES terminating:YES];
     }
     [_players removeAllObjects];
 }

--- a/just_audio/darwin/just_audio/Sources/just_audio/include/just_audio/AudioPlayer.h
+++ b/just_audio/darwin/just_audio/Sources/just_audio/include/just_audio/AudioPlayer.h
@@ -12,6 +12,7 @@
 
 - (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar playerId:(NSString*)idParam loadConfiguration:(NSDictionary *)loadConfiguration useLazyPreparation:(BOOL)useLazyPreparation;
 - (void)dispose:(BOOL)calledFromDealloc;
+- (void)dispose:(BOOL)calledFromDealloc terminating:(BOOL)terminating;
 
 @end
 

--- a/just_audio/darwin/just_audio/Sources/just_audio/include/just_audio/BetterEventChannel.h
+++ b/just_audio/darwin/just_audio/Sources/just_audio/include/just_audio/BetterEventChannel.h
@@ -9,6 +9,6 @@
 
 - (instancetype)initWithName:(NSString*)name messenger:(NSObject<FlutterBinaryMessenger> *)messenger;
 - (void)sendEvent:(id)event;
-- (void)dispose;
+- (void)dispose:(BOOL)terminating;
 
 @end

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and sequence any sound from any source (asset/file/URL/stream) in gapless playlists.
-version: 0.10.3
+version: 0.10.4
 repository: https://github.com/ryanheise/just_audio/tree/minor/just_audio
 issue_tracker: https://github.com/ryanheise/just_audio/issues
 topics:


### PR DESCRIPTION
Fixes #1479 

The dispose method on the `BetterEventChannel` was being called through the plugins `dealloc` method on app termination which would lead to the `NSInternalInconsistencyException` being thrown. This PR adds in an argument for if the app is terminating so the _eventSink is not used when the Flutter Engine has been shutdown.