### PR TITLE
Fix the default index and position when loading a source

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -912,8 +912,8 @@ class AudioPlayer {
         await _platform,
         _playlist,
         initialSeekValues: (
-          index: pluginLoadRequest?.initialIndex ?? currentIndex,
-          position: pluginLoadRequest?.initialPosition ?? position,
+          index: pluginLoadRequest?.initialIndex ?? 0,
+          position: pluginLoadRequest?.initialPosition ?? Duration.zero,
         ),
       );
     } else {


### PR DESCRIPTION
When updating to the latest version, I noticed that skipping or just moving to the next song after the previous ended now keeps the position of the last song. I think this was an accidentally changed in 1b210605341b55064a1ced3c5f91396bf0b8b3f9.

```dart
PlaybackEvent(
        currentIndex: initialIndex ?? 0,
        updatePosition: initialPosition ?? Duration.zero)
```
became
```dart
initialSeekValues: (
     index: pluginLoadRequest?.initialIndex ?? currentIndex,
     position: pluginLoadRequest?.initialPosition ?? position,
),
```