### PR TITLE
Add HLS precaching support for Android

### DIFF
--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
@@ -628,9 +628,19 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
                             .setTag(id)
                             .build());
         case "hls":
-            return new HlsMediaSource.Factory(buildDataSourceFactory(mapGet(map, "headers")))
+            String originalUri = (String) map.get("uri");
+            String cachedUri = JustAudioHLSDownloadManager.getInstance(context).getCachedUri(originalUri);
+            DataSource.Factory dataSourceFactory;
+
+            if (cachedUri != null) {
+                dataSourceFactory = JustAudioHLSDownloadManager.getInstance(context)
+                        .getCacheDataSourceFactory(mapGet(map, "headers"));
+            } else {
+                dataSourceFactory = buildDataSourceFactory(mapGet(map, "headers"));
+            }
+            return new HlsMediaSource.Factory(dataSourceFactory)
                     .createMediaSource(new MediaItem.Builder()
-                            .setUri(Uri.parse((String)map.get("uri")))
+                            .setUri(Uri.parse(originalUri))
                             .setMimeType(MimeTypes.APPLICATION_M3U8)
                             .build());
         case "silence":

--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/JustAudioHLSCachePlugin.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/JustAudioHLSCachePlugin.java
@@ -1,0 +1,198 @@
+package com.ryanheise.just_audio;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
+import io.flutter.plugin.common.MethodChannel.Result;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JustAudioHLSCachePlugin implements FlutterPlugin, MethodCallHandler {
+    private static final String TAG = "JustAudioHLSCache";
+    private static final String CHANNEL = "just_audio_hls_cache";
+
+    private MethodChannel channel;
+    private Context context;
+    private JustAudioHLSDownloadManager downloadManager;
+    private Handler mainHandler;
+
+    @Override
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
+        channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), CHANNEL);
+        channel.setMethodCallHandler(this);
+        context = flutterPluginBinding.getApplicationContext();
+        downloadManager = JustAudioHLSDownloadManager.getInstance(context);
+        mainHandler = new Handler(Looper.getMainLooper());
+        Log.d(TAG, "HLS Cache Plugin attached to engine");
+    }
+
+    @Override
+    public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
+        switch (call.method) {
+            case "downloadHLS":
+                downloadHLS(call, result);
+                break;
+            case "isHLSDownloaded":
+                isHLSDownloaded(call, result);
+                break;
+            case "getHLSDownloadProgress":
+                getHLSDownloadProgress(call, result);
+                break;
+            case "deleteHLSDownload":
+                deleteHLSDownload(call, result);
+                break;
+            case "cancelHLSDownload":
+                cancelHLSDownload(call, result);
+                break;
+            case "listDownloads":
+                listDownloads(result);
+                break;
+            case "clearAllDownloads":
+                clearAllDownloads(result);
+                break;
+            default:
+                result.notImplemented();
+                break;
+        }
+    }
+
+    private void downloadHLS(MethodCall call, Result result) {
+        String url = call.argument("url");
+        Map<String, String> headers = call.argument("headers");
+
+        if (url == null) {
+            result.error("INVALID_ARGUMENT", "URL cannot be null", null);
+            return;
+        }
+
+        if (headers == null) {
+            headers = new HashMap<>();
+        }
+        Log.d(TAG, "Starting HLS download for: " + url);
+
+        downloadManager.downloadHLS(url, headers, new DownloadProgressCallback() {
+            @Override
+            public void onProgress(double progress, String error) {
+                mainHandler.post(() -> {
+                    if (error != null) {
+                        Map<String, Object> response = new HashMap<>();
+                        response.put("success", false);
+                        response.put("error", error);
+                        result.success(response);
+                    } else if (progress >= 1.0) {
+                        Map<String, Object> response = new HashMap<>();
+                        response.put("success", true);
+                        result.success(response);
+                    }
+                });
+            }
+        });
+    }
+
+    private void isHLSDownloaded(MethodCall call, Result result) {
+        String url = call.argument("url");
+
+        if (url == null) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("isDownloaded", false);
+            result.success(response);
+            return;
+        }
+
+        boolean isDownloaded = downloadManager.isHLSDownloaded(url);
+        Map<String, Object> response = new HashMap<>();
+        response.put("isDownloaded", isDownloaded);
+        result.success(response);
+    }
+
+    private void getHLSDownloadProgress(MethodCall call, Result result) {
+        String url = call.argument("url");
+
+        if (url == null) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("progress", 0.0);
+            result.success(response);
+            return;
+        }
+
+        double progress = downloadManager.getHLSDownloadProgress(url);
+        Map<String, Object> response = new HashMap<>();
+        response.put("progress", progress);
+        result.success(response);
+    }
+
+    private void deleteHLSDownload(MethodCall call, Result result) {
+        String url = call.argument("url");
+
+        if (url == null) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("deleted", false);
+            result.success(response);
+            return;
+        }
+
+        boolean deleted = downloadManager.deleteHLSDownload(url);
+        Map<String, Object> response = new HashMap<>();
+        response.put("deleted", deleted);
+        result.success(response);
+    }
+
+    private void cancelHLSDownload(MethodCall call, Result result) {
+        String url = call.argument("url");
+
+        if (url == null) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("cancelled", false);
+            result.success(response);
+            return;
+        }
+
+        downloadManager.cancelHLSDownload(url);
+        Map<String, Object> response = new HashMap<>();
+        response.put("cancelled", true);
+        result.success(response);
+    }
+
+    private void listDownloads(Result result) {
+        List<Map<String, Object>> downloads = downloadManager.getAllHLSDownloads();
+        Map<String, Object> downloadMap = new HashMap<>();
+
+        for (Map<String, Object> download : downloads) {
+            String url = (String) download.get("url");
+            if (url != null) {
+                downloadMap.put(url, download);
+            }
+        }
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("downloads", downloadMap);
+        result.success(response);
+    }
+
+    private void clearAllDownloads(Result result) {
+        downloadManager.clearAllDownloads();
+        Map<String, Object> response = new HashMap<>();
+        response.put("cleared", true);
+        result.success(response);
+    }
+
+    @Override
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+        channel.setMethodCallHandler(null);
+        Log.d(TAG, "HLS Cache Plugin detached from engine");
+    }
+
+    public interface DownloadProgressCallback {
+        void onProgress(double progress, String error);
+    }
+}

--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/JustAudioHLSDownloadManager.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/JustAudioHLSDownloadManager.java
@@ -1,0 +1,456 @@
+package com.ryanheise.just_audio;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import androidx.media3.common.C;
+import androidx.media3.common.MimeTypes;
+import androidx.media3.common.util.Util;
+import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.media3.datasource.HttpDataSource;
+import androidx.media3.datasource.cache.NoOpCacheEvictor;
+import androidx.media3.datasource.cache.SimpleCache;
+import androidx.media3.database.StandaloneDatabaseProvider;
+import androidx.media3.exoplayer.offline.Download;
+import androidx.media3.exoplayer.offline.DownloadCursor;
+import androidx.media3.exoplayer.offline.DownloadIndex;
+import androidx.media3.exoplayer.offline.DownloadManager;
+import androidx.media3.exoplayer.offline.DownloadRequest;
+import androidx.media3.exoplayer.scheduler.Requirements;
+import androidx.media3.datasource.DataSource;
+import androidx.media3.datasource.DefaultDataSource;
+import androidx.media3.datasource.cache.CacheDataSource;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * Android HLS Download Manager using ExoPlayer's DownloadManager
+ */
+public class JustAudioHLSDownloadManager {
+    private static final String TAG = "JustAudioHLSDownloadManager";
+    private static final String DOWNLOAD_CONTENT_DIRECTORY = "just_audio_hls_downloads";
+
+    private static volatile JustAudioHLSDownloadManager INSTANCE;
+
+    private final Context context;
+    private DownloadManager downloadManager;
+    private SimpleCache downloadCache;
+    private final Map<String, JustAudioHLSCachePlugin.DownloadProgressCallback> downloadCallbacks = new ConcurrentHashMap<>();
+    private final Executor progressMonitorExecutor = Executors.newSingleThreadExecutor();
+
+    private JustAudioHLSDownloadManager(Context context) {
+        this.context = context.getApplicationContext();
+        initialize();
+    }
+
+    public static JustAudioHLSDownloadManager getInstance(Context context) {
+        if (INSTANCE == null) {
+            synchronized (JustAudioHLSDownloadManager.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = new JustAudioHLSDownloadManager(context);
+                }
+            }
+        }
+        return INSTANCE;
+    }
+
+    private void initialize() {
+        try {
+            Log.d(TAG, "Initializing HLS Download Manager...");
+
+            File downloadDirectory = new File(context.getCacheDir(), DOWNLOAD_CONTENT_DIRECTORY);
+            if (!downloadDirectory.exists()) {
+                downloadDirectory.mkdirs();
+            }
+
+            downloadCache = new SimpleCache(
+                    downloadDirectory,
+                    new NoOpCacheEvictor(),
+                    new StandaloneDatabaseProvider(context));
+
+            Requirements requirements = new Requirements(Requirements.NETWORK);
+
+            downloadManager = new DownloadManager(
+                    context,
+                    new StandaloneDatabaseProvider(context),
+                    downloadCache,
+                    createHttpDataSourceFactory(),
+                    Runnable::run);
+
+            downloadManager.setRequirements(requirements);
+            downloadManager.setMaxParallelDownloads(2);
+            downloadManager.setMinRetryCount(3);
+
+            downloadManager.addListener(new DownloadManager.Listener() {
+                @Override
+                public void onDownloadChanged(
+                        @NonNull DownloadManager downloadManager,
+                        @NonNull Download download,
+                        @Nullable Exception finalException) {
+                    String url = download.request.uri.toString();
+                    Log.d(TAG, "Download state changed: " + url + " -> " + getDownloadStateString(download.state));
+
+                    JustAudioHLSCachePlugin.DownloadProgressCallback callback = downloadCallbacks.get(url);
+                    if (callback != null) {
+                        if (finalException != null) {
+                            Log.e(TAG, "Download exception for " + url, finalException);
+                            callback.onProgress(0.0, finalException.getMessage());
+                            downloadCallbacks.remove(url);
+                        } else if (download.state == Download.STATE_COMPLETED) {
+                            Log.d(TAG, "Download completed for " + url);
+                            callback.onProgress(1.0, null);
+                            downloadCallbacks.remove(url);
+                        } else if (download.state == Download.STATE_FAILED) {
+                            String error = "Download failed with error code: " + download.failureReason;
+                            Log.e(TAG, error);
+                            callback.onProgress(0.0, error);
+                            downloadCallbacks.remove(url);
+                        }
+                    }
+                }
+
+                @Override
+                public void onDownloadRemoved(
+                        @NonNull DownloadManager downloadManager,
+                        @NonNull Download download) {
+                    Log.d(TAG, "Download removed: " + download.request.uri.toString());
+                }
+            });
+
+            downloadManager.resumeDownloads();
+
+            Log.d(TAG, "HLS Download Manager initialized successfully");
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to initialize HLS Download Manager", e);
+        }
+    }
+
+    public DataSource.Factory getCacheDataSourceFactory(Map<?, ?> headers) {
+        DefaultHttpDataSource.Factory httpDataSourceFactory = new DefaultHttpDataSource.Factory()
+                .setUserAgent(Util.getUserAgent(context, "just_audio"))
+                .setAllowCrossProtocolRedirects(true);
+
+        if (headers != null) {
+            Map<String, String> stringHeaders = new HashMap<>();
+            for (Object key : headers.keySet()) {
+                stringHeaders.put((String) key, (String) headers.get(key));
+            }
+            if (!stringHeaders.isEmpty()) {
+                httpDataSourceFactory.setDefaultRequestProperties(stringHeaders);
+            }
+        }
+        DefaultDataSource.Factory upstreamFactory = new DefaultDataSource.Factory(context, httpDataSourceFactory);
+
+        return new CacheDataSource.Factory()
+                .setCache(downloadCache)
+                .setUpstreamDataSourceFactory(upstreamFactory)
+                .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR);
+    }
+
+    private HttpDataSource.Factory createHttpDataSourceFactory() {
+        return new DefaultHttpDataSource.Factory()
+                .setUserAgent(Util.getUserAgent(context, "JustAudio"))
+                .setAllowCrossProtocolRedirects(true)
+                .setConnectTimeoutMs(DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS)
+                .setReadTimeoutMs(DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS);
+    }
+
+    /**
+     * Start HLS download for the given URL
+     */
+    public void downloadHLS(
+            String url,
+            Map<String, String> headers,
+            JustAudioHLSCachePlugin.DownloadProgressCallback callback) {
+        try {
+            Log.d(TAG, "Starting HLS download for URL: " + url);
+
+            if (downloadManager == null) {
+                callback.onProgress(0.0, "Download manager not initialized");
+                return;
+            }
+            Uri uri = Uri.parse(url);
+            String downloadId = url;
+            Download existingDownload = null;
+
+            try {
+                existingDownload = downloadManager.getDownloadIndex().getDownload(downloadId);
+            } catch (IOException e) {
+                Log.w(TAG, "Failed to check existing download", e);
+            }
+
+            if (existingDownload != null) {
+                Log.w(TAG, "Download already exists with state: " + getDownloadStateString(existingDownload.state));
+                switch (existingDownload.state) {
+                    case Download.STATE_COMPLETED:
+                        Log.d(TAG, "Download already completed");
+                        callback.onProgress(1.0, null);
+                        return;
+                    case Download.STATE_DOWNLOADING:
+                    case Download.STATE_QUEUED:
+                        Log.d(TAG, "Download already in progress, monitoring existing download");
+                        downloadCallbacks.put(url, callback);
+                        startProgressMonitoring(url, callback);
+                        return;
+                    case Download.STATE_FAILED:
+                        Log.w(TAG, "Removing failed download and starting fresh");
+                        downloadManager.removeDownload(downloadId);
+                        break;
+                }
+            }
+            String mimeType;
+
+            if (url.contains(".m3u8") || url.toLowerCase().contains("hls")) {
+                mimeType = MimeTypes.APPLICATION_M3U8;
+            } else {
+                Log.w(TAG, "URL doesn't appear to be HLS, but proceeding with HLS MIME type");
+                mimeType = MimeTypes.APPLICATION_M3U8;
+            }
+            DownloadRequest downloadRequest = new DownloadRequest.Builder(downloadId, uri)
+                    .setMimeType(mimeType)
+                    .build();
+
+            Log.d(TAG, "Created download request: ID=" + downloadRequest.id + ", URI=" + downloadRequest.uri
+                    + ", MimeType=" + mimeType);
+
+            downloadCallbacks.put(url, callback);
+            downloadManager.addDownload(downloadRequest);
+
+            startProgressMonitoring(url, callback);
+
+            Log.d(TAG, "Started HLS download for: " + url);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to start HLS download for URL: " + url, e);
+            callback.onProgress(0.0, "Failed to start download: " + e.getMessage());
+        }
+    }
+
+    private void startProgressMonitoring(String url, JustAudioHLSCachePlugin.DownloadProgressCallback callback) {
+        progressMonitorExecutor.execute(() -> {
+            String downloadId = url;
+            int checkCount = 0;
+
+            while (checkCount < 120 && downloadCallbacks.containsKey(url)) {
+                try {
+                    checkCount++;
+                    Download download = downloadManager.getDownloadIndex().getDownload(downloadId);
+
+                    if (download == null) {
+                        if (checkCount > 10) {
+                            Log.w(TAG, "Download not found after multiple attempts");
+                            callback.onProgress(0.0, "Download not found");
+                            downloadCallbacks.remove(url);
+                            break;
+                        }
+                    } else {
+                        double progress = getDownloadProgressForDownload(download);
+                        // Only call callback for intermediate progress, completion is handled by
+                        // listener
+                        if (download.state == Download.STATE_DOWNLOADING && progress < 1.0) {
+                            // Don't call callback here to avoid double-calling, the listener handles
+                            // completion
+                        }
+                    }
+
+                    Thread.sleep(1000); // Check every second
+                } catch (Exception e) {
+                    Log.e(TAG, "Error monitoring download progress", e);
+                    break;
+                }
+            }
+        });
+    }
+
+    /**
+     * Check if HLS is downloaded
+     */
+    public boolean isHLSDownloaded(String url) {
+        try {
+            String downloadId = url;
+            Download download = downloadManager.getDownloadIndex().getDownload(downloadId);
+            boolean isCompleted = download != null && download.state == Download.STATE_COMPLETED;
+            Log.d(TAG, "Checking download status for " + url + ": " + isCompleted);
+            return isCompleted;
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to check HLS download status for URL: " + url, e);
+            return false;
+        }
+    }
+
+    /**
+     * Get HLS download progress (0.0 to 1.0)
+     */
+    public double getHLSDownloadProgress(String url) {
+        try {
+            String downloadId = url;
+            Download download = downloadManager.getDownloadIndex().getDownload(downloadId);
+
+            if (download == null) {
+                return 0.0;
+            }
+            return getDownloadProgressForDownload(download);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to get HLS download progress for URL: " + url, e);
+            return 0.0;
+        }
+    }
+
+    private double getDownloadProgressForDownload(Download download) {
+        double percentDownloaded = download.getPercentDownloaded();
+        if (percentDownloaded != C.PERCENTAGE_UNSET) {
+            if (download.state == Download.STATE_COMPLETED)
+                return 1.0;
+            return Math.max(0.0, Math.min(1.0, percentDownloaded / 100.0));
+        }
+        long bytesDownloaded = download.getBytesDownloaded();
+        if (bytesDownloaded > 0) {
+            double estimatedProgress;
+            if (bytesDownloaded < 5 * 1024 * 1024) {
+                estimatedProgress = bytesDownloaded / (10.0 * 1024 * 1024);
+            } else if (bytesDownloaded < 15 * 1024 * 1024) {
+                estimatedProgress = 0.5 + (bytesDownloaded - 5 * 1024 * 1024) / (20.0 * 1024 * 1024);
+            } else {
+                estimatedProgress = 0.75 + (bytesDownloaded - 15 * 1024 * 1024) / (60.0 * 1024 * 1024);
+            }
+            return Math.min(0.95, estimatedProgress);
+        }
+        return 0.0;
+    }
+
+    /**
+     * Delete HLS download
+     */
+    public boolean deleteHLSDownload(String url) {
+        try {
+            String downloadId = url;
+            downloadManager.removeDownload(downloadId);
+            downloadCallbacks.remove(url);
+            Log.d(TAG, "Deleted HLS download for: " + url);
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to delete HLS download", e);
+            return false;
+        }
+    }
+
+    /**
+     * Cancel HLS download
+     */
+    public void cancelHLSDownload(String url) {
+        try {
+            String downloadId = url;
+            downloadManager.removeDownload(downloadId);
+
+            JustAudioHLSCachePlugin.DownloadProgressCallback callback = downloadCallbacks.remove(url);
+            if (callback != null) {
+                callback.onProgress(0.0, "Download cancelled");
+            }
+
+            Log.d(TAG, "Cancelled HLS download for: " + url);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to cancel HLS download", e);
+        }
+    }
+
+    /**
+     * Get all HLS downloads
+     */
+    public List<Map<String, Object>> getAllHLSDownloads() {
+        List<Map<String, Object>> downloads = new ArrayList<>();
+        try (DownloadCursor cursor = downloadManager.getDownloadIndex().getDownloads()) {
+            int count = 0;
+            while (cursor.moveToNext()) {
+                Download download = cursor.getDownload();
+                Log.d(TAG, "Found download: id=" + download.request.id + ", uri=" + download.request.uri + ", state="
+                        + download.state);
+                Map<String, Object> downloadInfo = new HashMap<>();
+                downloadInfo.put("url", download.request.uri.toString());
+                downloadInfo.put("id", download.request.id); // <-- add this
+                downloadInfo.put("progress", getDownloadProgressForDownload(download));
+                downloadInfo.put("isCompleted", download.state == Download.STATE_COMPLETED);
+                downloadInfo.put("state", getDownloadStateString(download.state));
+                downloads.add(downloadInfo);
+                count++;
+            }
+            Log.d(TAG, "Total downloads found: " + count);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to get all HLS downloads", e);
+        }
+        return downloads;
+    }
+
+    /**
+     * Clear all downloads
+     */
+    public void clearAllDownloads() {
+        try (DownloadCursor cursor = downloadManager.getDownloadIndex().getDownloads()) {
+            while (cursor.moveToNext()) {
+                Download download = cursor.getDownload();
+                downloadManager.removeDownload(download.request.id);
+            }
+            downloadCallbacks.clear();
+            Log.d(TAG, "Cleared all downloads");
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to clear all downloads", e);
+        }
+    }
+
+    /**
+     * Get cached URI for downloaded content (for offline playback)
+     */
+    @Nullable
+    public String getCachedUri(String url) {
+        try {
+            String downloadId = url;
+            Download download = downloadManager.getDownloadIndex().getDownload(downloadId);
+            if (download != null && download.state == Download.STATE_COMPLETED) {
+                return downloadId;
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to get cached URI for URL: " + url, e);
+        }
+        return null;
+    }
+
+    private String getDownloadStateString(int state) {
+        switch (state) {
+            case Download.STATE_QUEUED:
+                return "queued";
+            case Download.STATE_DOWNLOADING:
+                return "downloading";
+            case Download.STATE_COMPLETED:
+                return "completed";
+            case Download.STATE_FAILED:
+                return "failed";
+            case Download.STATE_REMOVING:
+                return "removing";
+            case Download.STATE_RESTARTING:
+                return "restarting";
+            case Download.STATE_STOPPED:
+                return "stopped";
+            default:
+                return "unknown";
+        }
+    }
+
+    /**
+     * Release resources
+     */
+    public void release() {
+        if (downloadManager != null) {
+            downloadManager.release();
+        }
+        downloadCallbacks.clear();
+    }
+}

--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/JustAudioPlugin.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/JustAudioPlugin.java
@@ -17,6 +17,7 @@ import io.flutter.plugin.common.MethodChannel.Result;
 public class JustAudioPlugin implements FlutterPlugin {
     private MethodChannel channel;
     private MainMethodCallHandler methodCallHandler;
+    private JustAudioHLSCachePlugin hlsCachePlugin;
 
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
@@ -26,6 +27,10 @@ public class JustAudioPlugin implements FlutterPlugin {
 
         channel = new MethodChannel(messenger, "com.ryanheise.just_audio.methods");
         channel.setMethodCallHandler(methodCallHandler);
+
+        hlsCachePlugin = new JustAudioHLSCachePlugin();
+        hlsCachePlugin.onAttachedToEngine(binding);
+
         @SuppressWarnings("deprecation")
         FlutterEngine engine = binding.getFlutterEngine();
         engine.addEngineLifecycleListener(new EngineLifecycleListener() {
@@ -44,6 +49,9 @@ public class JustAudioPlugin implements FlutterPlugin {
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
         methodCallHandler.dispose();
         methodCallHandler = null;
+
+        hlsCachePlugin.onDetachedFromEngine(binding);
+        hlsCachePlugin = null;
 
         channel.setMethodCallHandler(null);
     }

--- a/just_audio/example/lib/example_hls_caching.dart
+++ b/just_audio/example/lib/example_hls_caching.dart
@@ -1,0 +1,439 @@
+// ignore_for_file: use_build_context_synchronously
+
+import 'media_kit_stub.dart' if (dart.library.io) 'media_kit_impl.dart';
+import 'package:audio_session/audio_session.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:just_audio_example/common.dart';
+import 'package:rxdart/rxdart.dart';
+
+void main() {
+  initMediaKit();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: HlsCachingDemoPage(),
+    );
+  }
+}
+
+class HlsCachingDemoPage extends StatefulWidget {
+  const HlsCachingDemoPage({Key? key}) : super(key: key);
+
+  @override
+  HlsCachingDemoPageState createState() => HlsCachingDemoPageState();
+}
+
+class HlsCachingDemoPageState extends State<HlsCachingDemoPage>
+    with WidgetsBindingObserver {
+  final _player = AudioPlayer();
+
+  final _hlsAudioSource = HlsPrecachingAudioSource(
+    Uri.parse(
+        'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8'),
+    headers: {'User-Agent': 'MyAudioApp/1.0'},
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    ambiguate(WidgetsBinding.instance)!.addObserver(this);
+    SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
+      statusBarColor: Colors.black,
+    ));
+    _init();
+  }
+
+  Future<void> _init() async {
+    final session = await AudioSession.instance;
+    await session.configure(const AudioSessionConfiguration.speech());
+    _player.errorStream.listen((e) {
+      print('A stream error occurred: $e');
+    });
+
+    try {
+      // Check if already downloaded
+      await _hlsAudioSource.isStreamDownloaded();
+
+      // Set the audio source (will use cached version if available)
+      await _player.setAudioSource(_hlsAudioSource);
+    } on PlayerException catch (e) {
+      print("Error loading audio source: $e");
+    }
+  }
+
+  @override
+  void dispose() {
+    ambiguate(WidgetsBinding.instance)!.removeObserver(this);
+    _player.dispose();
+    _hlsAudioSource.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused) {
+      _player.stop();
+    }
+  }
+
+  /// Combines position, download progress, and duration into one stream
+  Stream<PositionData> get _positionDataStream =>
+      Rx.combineLatest3<Duration, double, Duration?, PositionData>(
+          _player.positionStream,
+          _hlsAudioSource.downloadProgressStream,
+          _player.durationStream,
+          (position, downloadProgress, reportedDuration) {
+        final duration = reportedDuration ?? Duration.zero;
+        final bufferedPosition = duration * downloadProgress;
+        return PositionData(position, bufferedPosition, duration);
+      });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('HLS Audio Caching Example'),
+      ),
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // Download controls
+            Card(
+              margin: const EdgeInsets.all(16),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'HLS Download Controls',
+                      style:
+                          TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 12),
+
+                    // Download status
+                    StreamBuilder<double>(
+                      stream: _hlsAudioSource.downloadProgressStream,
+                      builder: (context, snapshot) {
+                        final progress = snapshot.data ?? 0.0;
+                        final isDownloaded = progress >= 1.0;
+                        final isDownloading = _hlsAudioSource.isDownloading;
+
+                        return Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              isDownloaded
+                                  ? 'Status: Downloaded ✅'
+                                  : isDownloading
+                                      ? 'Status: Downloading... ${(progress * 100).toStringAsFixed(1)}%'
+                                      : 'Status: Not Downloaded',
+                              style: TextStyle(
+                                color: isDownloaded ? Colors.green : null,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            if (isDownloading) ...[
+                              LinearProgressIndicator(value: progress),
+                              const SizedBox(height: 8),
+                            ],
+                          ],
+                        );
+                      },
+                    ),
+
+                    // Download buttons
+                    Row(
+                      children: [
+                        Expanded(
+                          child: ElevatedButton(
+                            onPressed: _downloadHLS,
+                            child: const Text('Download'),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: ElevatedButton(
+                            onPressed: _cancelDownload,
+                            child: const Text('Cancel'),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: ElevatedButton(
+                            onPressed: _clearCache,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.red,
+                              foregroundColor: Colors.white,
+                            ),
+                            child: const Text('Delete'),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            // Player controls
+            ControlButtons(_player),
+
+            // Seek bar with download progress
+            StreamBuilder<PositionData>(
+              stream: _positionDataStream,
+              builder: (context, snapshot) {
+                final positionData = snapshot.data;
+                return SeekBar(
+                  duration: positionData?.duration ?? Duration.zero,
+                  position: positionData?.position ?? Duration.zero,
+                  bufferedPosition:
+                      positionData?.bufferedPosition ?? Duration.zero,
+                  onChangeEnd: _player.seek,
+                );
+              },
+            ),
+
+            const SizedBox(height: 16),
+
+            // Download management
+            Card(
+              margin: const EdgeInsets.all(16),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Download Management',
+                      style:
+                          TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      children: [
+                        ElevatedButton(
+                          onPressed: _listAllDownloads,
+                          child: const Text('List Downloads'),
+                        ),
+                        const SizedBox(width: 8),
+                        ElevatedButton(
+                          onPressed: _clearAllDownloads,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.orange,
+                            foregroundColor: Colors.white,
+                          ),
+                          child: const Text('Clear All'),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _downloadHLS() async {
+    try {
+      print('Starting HLS download...');
+      final success = await _hlsAudioSource.download();
+      if (success) {
+        print('HLS download started successfully');
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Download completed')),
+        );
+      } else {
+        print('Failed to start HLS download');
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to start download')),
+        );
+      }
+    } catch (e) {
+      print('Error starting download: $e');
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error: $e')),
+      );
+    }
+  }
+
+  Future<void> _cancelDownload() async {
+    try {
+      final cancelled = await _hlsAudioSource.cancelDownload();
+      if (cancelled) {
+        print('Download cancelled');
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Download cancelled')),
+        );
+      }
+    } catch (e) {
+      print('Error cancelling download: $e');
+    }
+  }
+
+  Future<void> _clearCache() async {
+    try {
+      final cleared = await _hlsAudioSource.clearCache();
+      if (cleared) {
+        print('Cache cleared');
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Cache cleared')),
+        );
+      }
+    } catch (e) {
+      print('Error clearing cache: $e');
+    }
+  }
+
+  Future<void> _listAllDownloads() async {
+    try {
+      final downloads = await HlsPrecachingAudioSource.listAllDownloads();
+      print('All downloads: $downloads');
+
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Downloaded Content'),
+          content: downloads.isEmpty
+              ? const Text('No downloads found')
+              : Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: downloads.entries
+                      .map((entry) => Text('${entry.key}: ${entry.value}'))
+                      .toList(),
+                ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    } catch (e) {
+      print('Error listing downloads: $e');
+    }
+  }
+
+  Future<void> _clearAllDownloads() async {
+    try {
+      final cleared = await HlsPrecachingAudioSource.clearAllDownloads();
+      if (cleared) {
+        print('All downloads cleared');
+        _hlsAudioSource.clearCache();
+        setState(() {});
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('All downloads cleared')),
+        );
+      }
+    } catch (e) {
+      print('Error clearing all downloads: $e');
+    }
+  }
+}
+
+/// Displays the play/pause button and volume/speed sliders.
+class ControlButtons extends StatelessWidget {
+  final AudioPlayer player;
+
+  const ControlButtons(this.player, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Volume control
+        IconButton(
+          icon: const Icon(Icons.volume_up),
+          onPressed: () {
+            showSliderDialog(
+              context: context,
+              title: "Adjust volume",
+              divisions: 10,
+              min: 0.0,
+              max: 1.0,
+              value: player.volume,
+              stream: player.volumeStream,
+              onChanged: player.setVolume,
+            );
+          },
+        ),
+
+        // Play/pause button with loading indicator
+        StreamBuilder<PlayerState>(
+          stream: player.playerStateStream,
+          builder: (context, snapshot) {
+            final playerState = snapshot.data;
+            final processingState = playerState?.processingState;
+            final playing = playerState?.playing;
+            if (processingState == ProcessingState.loading ||
+                processingState == ProcessingState.buffering) {
+              return Container(
+                margin: const EdgeInsets.all(8.0),
+                width: 64.0,
+                height: 64.0,
+                child: const CircularProgressIndicator(),
+              );
+            } else if (playing != true) {
+              return IconButton(
+                icon: const Icon(Icons.play_arrow),
+                iconSize: 64.0,
+                onPressed: player.play,
+              );
+            } else if (processingState != ProcessingState.completed) {
+              return IconButton(
+                icon: const Icon(Icons.pause),
+                iconSize: 64.0,
+                onPressed: player.pause,
+              );
+            } else {
+              return IconButton(
+                icon: const Icon(Icons.replay),
+                iconSize: 64.0,
+                onPressed: () => player.seek(Duration.zero),
+              );
+            }
+          },
+        ),
+
+        // Speed control
+        StreamBuilder<double>(
+          stream: player.speedStream,
+          builder: (context, snapshot) => IconButton(
+            icon: Text("${snapshot.data?.toStringAsFixed(1)}x",
+                style: const TextStyle(fontWeight: FontWeight.bold)),
+            onPressed: () {
+              showSliderDialog(
+                context: context,
+                title: "Adjust speed",
+                divisions: 10,
+                min: 0.5,
+                max: 1.5,
+                value: player.speed,
+                stream: player.speedStream,
+                onChanged: player.setSpeed,
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1001,13 +1001,14 @@ class AudioPlayer {
       source._shuffle(initialIndex: initialSeekValues?.index ?? 0);
       await _broadcastSequence();
       checkInterruption();
-      _loadFuture = platform
-          .load(LoadRequest(
-            audioSourceMessage: source._toMessage(),
-            initialPosition: initialSeekValues?.position,
-            initialIndex: initialSeekValues?.index,
-          ))
-          .then((response) => response.duration);
+      final loadRequest = LoadRequest(
+        audioSourceMessage: source._toMessage(),
+        initialPosition: initialSeekValues?.position,
+        initialIndex: initialSeekValues?.index,
+      );
+
+      _loadFuture =
+          platform.load(loadRequest).then((response) => response.duration);
       final duration = await _loadFuture;
       checkInterruption();
       if (platform != _platformValue) {
@@ -2834,7 +2835,7 @@ class HlsAudioSource extends UriAudioSource {
   @override
   AudioSourceMessage _toMessage() => HlsAudioSourceMessage(
         id: _id,
-        uri: _effectiveUri.toString(),
+        uri: uri.toString(),
         headers: _mergedHeaders,
         tag: tag,
       );
@@ -4563,3 +4564,202 @@ HttpClient _createHttpClient({String? userAgent}) {
   }
   return client;
 }
+
+/// An [AudioSource] representing an HLS stream with precaching support.
+/// This allows you to download HLS audio streams for offline playback.
+///
+/// On iOS, this uses AVAssetDownloadTask to download the HLS stream to
+/// .movpkg files. On Android, this uses ExoPlayer's DownloadManager.
+///
+/// Example usage:
+/// ```dart
+/// final hlsCachingSource = HlsPrecachingAudioSource(
+///   Uri.parse('https://example.com/audio.m3u8'),
+///   headers: {'Authorization': 'Bearer token'},
+/// );
+///
+/// // Start download
+/// await hlsCachingSource.download();
+///
+/// // Check download progress
+/// hlsCachingSource.downloadProgressStream.listen((progress) {
+///   print('Download progress: ${(progress * 100).toStringAsFixed(1)}%');
+/// });
+///
+/// // Play (will use cached version if available)
+/// await player.setAudioSource(hlsCachingSource);
+/// ```
+@experimental
+class HlsPrecachingAudioSource extends HlsAudioSource {
+  static const MethodChannel _channel = MethodChannel('just_audio_hls_cache');
+
+  final _downloadProgressSubject = BehaviorSubject<double>.seeded(0.0);
+  bool _isDownloading = false;
+  bool _isDownloaded = false;
+
+  /// Creates an [HlsPrecachingAudioSource] that can download and cache HLS audio streams.
+  HlsPrecachingAudioSource(
+    Uri uri, {
+    Map<String, String>? headers,
+    dynamic tag,
+    Duration? duration,
+  }) : super(uri, headers: headers, tag: tag, duration: duration);
+
+  /// Emits the current download progress as a double value from 0.0 (nothing
+  /// downloaded) to 1.0 (download complete).
+  Stream<double> get downloadProgressStream => _downloadProgressSubject.stream;
+
+  /// Whether the HLS stream is currently being downloaded.
+  bool get isDownloading => _isDownloading;
+
+  /// Whether the HLS stream has been fully downloaded.
+  bool get isDownloaded => _isDownloaded;
+
+  /// Starts downloading the HLS stream for offline playback.
+  /// Returns true if download started successfully or is already complete.
+  Future<bool> download() async {
+    if (_isDownloaded) {
+      _downloadProgressSubject.add(1.0);
+      return true;
+    }
+
+    if (_isDownloading) {
+      return true; // Already downloading
+    }
+
+    try {
+      _isDownloading = true;
+      _monitorDownloadProgress();
+
+      final result = await _channel.invokeMethod('downloadHLS', {
+        'url': uri.toString(),
+        'headers': headers ?? <String, String>{},
+      });
+
+      // If download starts successfully (native side returns right away, even if download isn't finished)
+      if (result['success'] == true) {
+        return true;
+      } else {
+        _isDownloading = false;
+        throw Exception('Failed to start download: ${result['error']}');
+      }
+    } catch (e) {
+      _isDownloading = false;
+      rethrow;
+    }
+  }
+
+  /// Monitors download progress and updates the progress stream.
+  Future<void> _monitorDownloadProgress() async {
+    while (_isDownloading && !_isDownloaded) {
+      try {
+        final result = await _channel.invokeMethod('getHLSDownloadProgress', {
+          'url': uri.toString(),
+        });
+
+        final progress = (result['progress'] as num?)?.toDouble() ?? 0.0;
+        _downloadProgressSubject.add(progress);
+
+        if (progress >= 1.0) {
+          _isDownloaded = true;
+          _isDownloading = false;
+          break;
+        }
+
+        await Future.delayed(const Duration(milliseconds: 500));
+      } catch (e) {
+        _isDownloading = false;
+        break;
+      }
+    }
+  }
+
+  /// Checks if the HLS stream is already downloaded.
+  Future<bool> isStreamDownloaded() async {
+    try {
+      final result = await _channel.invokeMethod('isHLSDownloaded', {
+        'url': uri.toString(),
+      });
+      _isDownloaded = result['isDownloaded'] == true;
+      if (_isDownloaded) {
+        _downloadProgressSubject.add(1.0);
+      } else {
+        _monitorDownloadProgress();
+      }
+      return _isDownloaded;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /// Cancels an ongoing download.
+  Future<bool> cancelDownload() async {
+    try {
+      final result = await _channel.invokeMethod('cancelHLSDownload', {
+        'url': uri.toString(),
+      });
+
+      if (result['cancelled'] == true) {
+        _isDownloading = false;
+        _downloadProgressSubject.add(0.0);
+        return true;
+      }
+      return false;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /// Deletes the downloaded HLS stream.
+  Future<bool> clearCache() async {
+    try {
+      final result = await _channel.invokeMethod('deleteHLSDownload', {
+        'url': uri.toString(),
+      });
+
+      if (result['deleted'] == true) {
+        _isDownloaded = false;
+        _isDownloading = false;
+        _downloadProgressSubject.add(0.0);
+        return true;
+      }
+      return false;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /// Returns an [AudioSource] that uses the cached version if available,
+  /// otherwise returns the original HLS source.
+  Future<AudioSource> resolve() async {
+    await isStreamDownloaded();
+    return this; // The native layer will automatically use cached version if available
+  }
+
+  /// Disposes resources used by this audio source.
+  void dispose() {
+    _downloadProgressSubject.close();
+  }
+
+  /// Static method to clear all HLS downloads.
+  static Future<bool> clearAllDownloads() async {
+    try {
+      final result = await _channel.invokeMethod('clearAllDownloads');
+      return result['cleared'] == true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /// Static method to list all downloaded HLS streams.
+  static Future<Map<String, dynamic>> listAllDownloads() async {
+    try {
+      final result = await _channel.invokeMethod('listDownloads');
+      final downloads = result['downloads'] as Map?;
+      return Map<String, dynamic>.from(downloads ?? {});
+    } catch (e) {
+      return {};
+    }
+  }
+}
+


### PR DESCRIPTION
This work introduces support for scenarios where we want to precache data and play it directly from the local cache.

To test playback from cache, you have to make this change:

```
class HlsAudioSource extends UriAudioSource {
  HlsAudioSource(Uri uri,
      {Map<String, String>? headers, dynamic tag, Duration? duration})
      : super(uri, headers: headers, tag: tag, duration: duration);

  @override
  AudioSourceMessage _toMessage() => HlsAudioSourceMessage(
        id: _id,
        // Previously: uri: _effectiveUri.toString(),
        uri: uri.toString(), // Now uses the original (potentially local) URI
        headers: _mergedHeaders,
        tag: tag,
      );
}
```

With this change, we can use a local file URI when needed, enabling playback from a locally cached file instead of always fetching from a remote URL.

I'm considering a cleaner way to bypass the local URL logic when needed, so suggestions or alternative approaches are welcome!

I'm moving on to implement similar support on the iOS side next. 

Please let me know if you find this useful or have any feedback, especially regarding the local URL bypass or improvements for broader platform support.
