### PR TITLE
Modify just_audio.podspec to include `mm` in source files 

### DIFF
--- a/just_audio/darwin/just_audio.podspec
+++ b/just_audio/darwin/just_audio.podspec
@@ -12,7 +12,7 @@ A flutter plugin for playing audio.
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Your Company' => 'email@example.com' }
   s.source           = { :path => '.' }
-  s.source_files = 'just_audio/Sources/just_audio/**/*.{h,m}'
+  s.source_files = 'just_audio/Sources/just_audio/**/*.{h,m,mm}'
   s.public_header_files = 'just_audio/Sources/just_audio/include/**/*.h'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'


### PR DESCRIPTION
This fixes the #1475  issue with Android_FFT missing. Thanks to @w-rui