### PR TITLE
Add support for HLS streams in just_audio_web

### DIFF
--- a/just_audio/CHANGELOG.md
+++ b/just_audio/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.10.5
 
-* Add support for HLS streams in just_audio_web (@dindils)
+* Add support for HLS streams in just_audio_web (@dindils, @liorshk, @aletorrado)
 
 ## 0.10.4
 

--- a/just_audio/CHANGELOG.md
+++ b/just_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.5
+
+* Add support for HLS streams in just_audio_web (@dindils)
+
 ## 0.10.4
 
 * Fix bug on simultaneous loads.

--- a/just_audio/README.md
+++ b/just_audio/README.md
@@ -352,7 +352,7 @@ For issues with the Linux implementation, please open an issue on the respective
 To enable HLS (HTTP Live Streaming) playback in the web player, add the following script tag to your HTML file:
 
 ```html
-<script src="//cdn.jsdelivr.net/npm/hls.js@1"></script>
+<script async src="//cdn.jsdelivr.net/npm/hls.js@1"></script>
 ```
 
 ## Troubleshooting

--- a/just_audio/README.md
+++ b/just_audio/README.md
@@ -347,6 +347,14 @@ dependencies:
 
 For issues with the Linux implementation, please open an issue on the respective implementation's GitHub issues page.
 
+### Web
+
+To enable HLS (HTTP Live Streaming) playback in the web player, add the following script tag to your HTML file:
+
+```html
+<script src="//cdn.jsdelivr.net/npm/hls.js@1"></script>
+```
+
 ## Troubleshooting
 
 Most problems you encounter when playing an audio file will likely relate to the audio file format, the server headers, or the file name.
@@ -413,7 +421,7 @@ Please also consider pressing the thumbs up button at the top of [this page](htt
 | read from byte stream          | ✅      | ✅  | ✅    | ✅  | ✅      | ✅    |
 | request headers                | ✅      | ✅  | ✅    | *   | ✅      | ✅    |
 | DASH                           | ✅      |     |       |     | ✅      | ✅    |
-| HLS                            | ✅      | ✅  | ✅    |     | ✅      | ✅    |
+| HLS                            | ✅      | ✅  | ✅    | ✅   | ✅      | ✅    |
 | ICY metadata                   | ✅      | ✅  | ✅    |     |         |       |
 | buffer status/position         | ✅      | ✅  | ✅    | ✅  | ✅      | ✅    |
 | play/pause/seek                | ✅      | ✅  | ✅    | ✅  | ✅      | ✅    |

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -2720,6 +2720,7 @@ abstract class UriAudioSource extends IndexedAudioSource {
         '.aifc': 'audio/x-aiff',
         '.aiff': 'audio/x-aiff',
         '.m3u': 'audio/x-mpegurl',
+        '.m3u8': 'application/x-mpegurl',
       };
       // Default to 'audio/mpeg'
       final mimeType =

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and sequence any sound from any source (asset/file/URL/stream) in gapless playlists.
-version: 0.10.4
+version: 0.10.5
 repository: https://github.com/ryanheise/just_audio/tree/minor/just_audio
 issue_tracker: https://github.com/ryanheise/just_audio/issues
 topics:

--- a/just_audio_web/CHANGELOG.md
+++ b/just_audio_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.17
+
+* Add support for HLS streams in just_audio_web (@dindils)
+
 ## 0.4.16
 
 * Fix play interrupted by load.

--- a/just_audio_web/CHANGELOG.md
+++ b/just_audio_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.17
 
-* Add support for HLS streams in just_audio_web (@dindils)
+* Add support for HLS streams in just_audio_web (@dindils, @liorshk, @aletorrado)
 
 ## 0.4.16
 

--- a/just_audio_web/lib/extra.dart
+++ b/just_audio_web/lib/extra.dart
@@ -1,7 +1,7 @@
 class NoScriptTagException implements Exception {
   @override
   String toString() =>
-      'Did you add   <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"  type="application/javascript"></script> in index.html? ';
+      'Did you add <script async src="//cdn.jsdelivr.net/npm/hls.js@1"></script> in index.html? ';
 }
 
 // An error code value to error name Map.

--- a/just_audio_web/lib/extra.dart
+++ b/just_audio_web/lib/extra.dart
@@ -1,0 +1,29 @@
+class NoScriptTagException implements Exception {
+  @override
+  String toString() =>
+      'Did you add   <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"  type="application/javascript"></script> in index.html? ';
+}
+
+// An error code value to error name Map.
+// See: https://developer.mozilla.org/en-US/docs/Web/API/MediaError/code
+const Map<int, String> kErrorValueToErrorName = <int, String>{
+  1: 'MEDIA_ERR_ABORTED',
+  2: 'MEDIA_ERR_NETWORK',
+  3: 'MEDIA_ERR_DECODE',
+  4: 'MEDIA_ERR_SRC_NOT_SUPPORTED',
+};
+
+// An error code value to description Map.
+// See: https://developer.mozilla.org/en-US/docs/Web/API/MediaError/code
+const Map<int, String> kErrorValueToErrorDescription = <int, String>{
+  1: 'The user canceled the fetching of the video.',
+  2: 'A network error occurred while fetching the video, despite having previously been available.',
+  3: 'An error occurred while trying to decode the video, despite having previously been determined to be usable.',
+  4: 'The video has been found to be unsuitable (missing or in a format not supported by your browser).',
+  5: 'Could not load manifest'
+};
+
+// The default error message, when the error is an empty string
+// See: https://developer.mozilla.org/en-US/docs/Web/API/MediaError/message
+const String kDefaultErrorMessage =
+    'No further diagnostic information can be determined or provided.';

--- a/just_audio_web/lib/hls.dart
+++ b/just_audio_web/lib/hls.dart
@@ -1,0 +1,38 @@
+@JS()
+library hls.js;
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'package:web/web.dart';
+
+@JS('Hls.isSupported')
+external bool isSupported();
+
+extension type Hls._(JSObject _) implements JSObject {
+  external factory Hls(HlsConfig config);
+
+  external void stopLoad();
+  external void loadSource(String videoSrc);
+  external void attachMedia(HTMLAudioElement video);
+  external void on(String event, JSFunction callback);
+
+  external HlsConfig get config;
+}
+
+extension type HlsConfig._(JSObject _) implements JSObject {
+  external factory HlsConfig({JSFunction xhrSetup, JSBoolean debug});
+  external JSFunction get xhrSetup;
+  external JSBoolean get debug;
+}
+
+class HlsError {
+  late final String type;
+  late final String details;
+  late final bool fatal;
+
+  HlsError(JSObject errorData) {
+    type = errorData.getProperty<JSString>("type".toJS).toDart;
+    details = errorData.getProperty<JSString>("details".toJS).toDart;
+    fatal = errorData.getProperty<JSBoolean>("fatal".toJS).toDart;
+  }
+}

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -237,13 +237,13 @@ class Html5AudioPlayer extends JustAudioPlayer {
         _hls!.on(
           'hlsError',
           ((JSObject _, JSObject data) {
-            final HlsError _data = HlsError(data);
-            if (_data.fatal) {
+            final HlsError hlsData = HlsError(data);
+            if (hlsData.fatal) {
               _eventController.addError(
                 PlatformException(
                   code: kErrorValueToErrorName[2]!,
-                  message: _data.type,
-                  details: _data.details,
+                  message: hlsData.type,
+                  details: hlsData.details,
                 ),
               );
             }
@@ -270,7 +270,9 @@ class Html5AudioPlayer extends JustAudioPlayer {
         'application/vnd.apple.mpegurl',
       );
       canPlayHls = canPlayType != '';
-    } catch (e) {}
+    } catch (e) {
+      canPlayHls = false;
+    }
     return canPlayHls;
   }
 

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -215,9 +215,10 @@ class Html5AudioPlayer extends JustAudioPlayer {
       try {
         _hls = Hls(
           HlsConfig(
-            debug: true.toJS, // Enable debug logging in HLS.js
+            debug: false.toJS, // Enable to output debug logging in HLS.js
             xhrSetup: ((JSObject xhr, String _) {
               return;
+              // Note: Not tested yet, but could be used to set headers for HLS requests.
               // if (headers.isEmpty) {
               //   return;
               // }
@@ -389,7 +390,6 @@ class Html5AudioPlayer extends JustAudioPlayer {
 
       _durationCompleter = Completer<dynamic>();
       _audioElement.id = 'audioPlayer-$id';
-      _audioElement.src = src;
       _audioElement.playbackRate = _speed;
       _audioElement.preload = 'auto';
       ui_web.platformViewRegistry.registerViewFactory(
@@ -401,6 +401,7 @@ class Html5AudioPlayer extends JustAudioPlayer {
         // handled in function
       } else {
         // normal audio
+        _audioElement.src = src;
         await _audioElementQueue.load();
       }
 

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -3,7 +3,6 @@ import 'dart:js_interop';
 import 'dart:math';
 import 'dart:ui_web' as ui_web;
 
-import 'package:logging/logging.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
@@ -217,22 +216,21 @@ class Html5AudioPlayer extends JustAudioPlayer {
         _hls = Hls(
           HlsConfig(
             debug: true.toJS, // Enable debug logging in HLS.js
-            xhrSetup:
-                ((JSObject xhr, String _) {
-                  return;
-                  // if (headers.isEmpty) {
-                  //   return;
-                  // }
+            xhrSetup: ((JSObject xhr, String _) {
+              return;
+              // if (headers.isEmpty) {
+              //   return;
+              // }
 
-                  // if (headers.containsKey('useCookies')) {
-                  //   xhr.withCredentials = true;
-                  // }
-                  // headers.forEach((String key, String value) {
-                  //   if (key != 'useCookies') {
-                  //     xhr.setRequestHeader(key, value);
-                  //   }
-                  // });
-                }).toJS,
+              // if (headers.containsKey('useCookies')) {
+              //   xhr.withCredentials = true;
+              // }
+              // headers.forEach((String key, String value) {
+              //   if (key != 'useCookies') {
+              //     xhr.setRequestHeader(key, value);
+              //   }
+              // });
+            }).toJS,
           ),
         );
 
@@ -497,11 +495,10 @@ class Html5AudioPlayer extends JustAudioPlayer {
   Future<SetWebCrossOriginResponse> setWebCrossOrigin(
     SetWebCrossOriginRequest request,
   ) async {
-    _audioElement.crossOrigin =
-        const {
-          WebCrossOriginMessage.anonymous: 'anonymous',
-          WebCrossOriginMessage.useCredentials: 'use-credentials',
-        }[request.crossOrigin];
+    _audioElement.crossOrigin = const {
+      WebCrossOriginMessage.anonymous: 'anonymous',
+      WebCrossOriginMessage.useCredentials: 'use-credentials',
+    }[request.crossOrigin];
     return SetWebCrossOriginResponse();
   }
 
@@ -543,7 +540,8 @@ class Html5AudioPlayer extends JustAudioPlayer {
     _concatenating(request.id)!.setShuffleOrder(request.shuffleOrder);
     _concatenating(
       request.id,
-    )!.insertAll(request.index, getAudioSources(request.children));
+    )!
+        .insertAll(request.index, getAudioSources(request.children));
     if (_index != null && wasNotEmpty && request.index <= _index!) {
       _index = _index! + request.children.length;
     }
@@ -566,7 +564,8 @@ class Html5AudioPlayer extends JustAudioPlayer {
     _concatenating(request.id)!.setShuffleOrder(request.shuffleOrder);
     _concatenating(
       request.id,
-    )!.removeRange(request.startIndex, request.endIndex);
+    )!
+        .removeRange(request.startIndex, request.endIndex);
     if (_index != null) {
       if (_index! >= request.startIndex && _index! < request.endIndex) {
         // Skip backward if there's nothing after this
@@ -622,7 +621,7 @@ class Html5AudioPlayer extends JustAudioPlayer {
 
   @override
   Future<SetAutomaticallyWaitsToMinimizeStallingResponse>
-  setAutomaticallyWaitsToMinimizeStalling(
+      setAutomaticallyWaitsToMinimizeStalling(
     SetAutomaticallyWaitsToMinimizeStallingRequest request,
   ) async {
     return SetAutomaticallyWaitsToMinimizeStallingResponse();
@@ -630,7 +629,7 @@ class Html5AudioPlayer extends JustAudioPlayer {
 
   @override
   Future<SetCanUseNetworkResourcesForLiveStreamingWhilePausedResponse>
-  setCanUseNetworkResourcesForLiveStreamingWhilePaused(
+      setCanUseNetworkResourcesForLiveStreamingWhilePaused(
     SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest request,
   ) async {
     return SetCanUseNetworkResourcesForLiveStreamingWhilePausedResponse();
@@ -673,7 +672,7 @@ class Html5AudioPlayer extends JustAudioPlayer {
   AudioSourcePlayer getAudioSource(AudioSourceMessage audioSourceMessage) {
     final id = audioSourceMessage.id;
     var audioSourcePlayer = _audioSourcePlayers[id];
-    if (audioSourcePlayer == null) {
+    if (audioSourcePlayer == null || id.isEmpty) {
       audioSourcePlayer = decodeAudioSource(audioSourceMessage);
       _audioSourcePlayers[id] = audioSourcePlayer;
     }
@@ -752,7 +751,7 @@ abstract class AudioSourcePlayer {
 /// A player for an [IndexedAudioSourceMessage].
 abstract class IndexedAudioSourcePlayer extends AudioSourcePlayer {
   IndexedAudioSourcePlayer(Html5AudioPlayer html5AudioPlayer, String id)
-    : super(html5AudioPlayer, id);
+      : super(html5AudioPlayer, id);
 
   /// Loads the audio for the underlying audio source.
   Future<Duration?> load([int? initialPosition]);
@@ -937,8 +936,8 @@ class ConcatenatingAudioSourcePlayer extends AudioSourcePlayer {
     this.audioSourcePlayers,
     this.useLazyPreparation,
     List<int> shuffleOrder,
-  ) : _shuffleOrder = shuffleOrder,
-      super(html5AudioPlayer, id);
+  )   : _shuffleOrder = shuffleOrder,
+        super(html5AudioPlayer, id);
 
   @override
   List<IndexedAudioSourcePlayer> get sequence =>
@@ -1034,8 +1033,7 @@ class ClippingAudioSourcePlayer extends IndexedAudioSourcePlayer {
     _initialPos = null;
     if (fullDuration != null) {
       _duration = Duration(
-        milliseconds:
-            min(
+        milliseconds: min(
               (end ?? fullDuration).inMilliseconds,
               fullDuration.inMilliseconds,
             ) -
@@ -1159,8 +1157,7 @@ class LoopingAudioSourcePlayer extends AudioSourcePlayer {
   ) : super(html5AudioPlayer, id);
 
   @override
-  List<IndexedAudioSourcePlayer> get sequence =>
-      List.generate(
+  List<IndexedAudioSourcePlayer> get sequence => List.generate(
         count,
         (i) => audioSourcePlayer,
       ).expand((p) => p.sequence).toList();

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -1,13 +1,18 @@
 import 'dart:async';
 import 'dart:js_interop';
 import 'dart:math';
+import 'dart:ui_web' as ui_web;
 
+import 'package:logging/logging.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:just_audio_platform_interface/just_audio_platform_interface.dart';
 import 'package:synchronized/synchronized.dart' as synch;
 import 'package:web/web.dart';
+
+import 'hls.dart';
+import 'extra.dart';
 
 /// The web implementation of [JustAudioPlatform].
 class JustAudioPlugin extends JustAudioPlatform {
@@ -22,8 +27,9 @@ class JustAudioPlugin extends JustAudioPlatform {
   Future<AudioPlayerPlatform> init(InitRequest request) async {
     if (players.containsKey(request.id)) {
       throw PlatformException(
-          code: "error",
-          message: "Platform player ${request.id} already exists");
+        code: "error",
+        message: "Platform player ${request.id} already exists",
+      );
     }
     final player = Html5AudioPlayer(id: request.id);
     players[request.id] = player;
@@ -32,7 +38,8 @@ class JustAudioPlugin extends JustAudioPlatform {
 
   @override
   Future<DisposePlayerResponse> disposePlayer(
-      DisposePlayerRequest request) async {
+    DisposePlayerRequest request,
+  ) async {
     await players[request.id]?.release();
     players.remove(request.id);
     return DisposePlayerResponse();
@@ -40,7 +47,8 @@ class JustAudioPlugin extends JustAudioPlatform {
 
   @override
   Future<DisposeAllPlayersResponse> disposeAllPlayers(
-      DisposeAllPlayersRequest request) async {
+    DisposeAllPlayersRequest request,
+  ) async {
     for (var player in players.values) {
       await player.release();
     }
@@ -51,10 +59,12 @@ class JustAudioPlugin extends JustAudioPlatform {
 
 /// The web impluementation of [AudioPlayerPlatform].
 abstract class JustAudioPlayer extends AudioPlayerPlatform {
-  final _eventController =
-      StreamController<PlaybackEventMessage>.broadcast(sync: true);
-  final _dataEventController =
-      StreamController<PlayerDataMessage>.broadcast(sync: true);
+  final _eventController = StreamController<PlaybackEventMessage>.broadcast(
+    sync: true,
+  );
+  final _dataEventController = StreamController<PlayerDataMessage>.broadcast(
+    sync: true,
+  );
   ProcessingStateMessage _processingState = ProcessingStateMessage.idle;
   bool _playing = false;
   int? _index;
@@ -83,19 +93,21 @@ abstract class JustAudioPlayer extends AudioPlayerPlatform {
   /// Broadcasts a playback event from the platform side to the plugin side.
   void broadcastPlaybackEvent() {
     var updateTime = DateTime.now();
-    _eventController.add(PlaybackEventMessage(
-      processingState: _processingState,
-      updatePosition: getCurrentPosition(),
-      updateTime: updateTime,
-      bufferedPosition: getBufferedPosition(),
-      // TODO: Icy Metadata
-      icyMetadata: null,
-      duration: getDuration(),
-      currentIndex: _index,
-      androidAudioSessionId: null,
-      errorCode: errorCode,
-      errorMessage: errorMessage,
-    ));
+    _eventController.add(
+      PlaybackEventMessage(
+        processingState: _processingState,
+        updatePosition: getCurrentPosition(),
+        updateTime: updateTime,
+        bufferedPosition: getBufferedPosition(),
+        // TODO: Icy Metadata
+        icyMetadata: null,
+        duration: getDuration(),
+        currentIndex: _index,
+        androidAudioSessionId: null,
+        errorCode: errorCode,
+        errorMessage: errorMessage,
+      ),
+    );
   }
 
   /// Transitions to [processingState] and broadcasts a playback event.
@@ -120,66 +132,152 @@ class Html5AudioPlayer extends JustAudioPlayer {
   LoopModeMessage _loopMode = LoopModeMessage.off;
   bool _shuffleModeEnabled = false;
   final Map<String, AudioSourcePlayer> _audioSourcePlayers = {};
+  Hls? _hls;
 
   /// Creates an [Html5AudioPlayer] with the given [id].
   Html5AudioPlayer({required String id}) : super(id: id) {
     _audioElement.addEventListener(
-        'durationchange',
-        (Event event) {
-          _durationCompleter?.complete();
-          _durationCompleter = null;
-          broadcastPlaybackEvent();
-        }.toJS);
+      'durationchange',
+      (Event event) {
+        _durationCompleter?.complete();
+        _durationCompleter = null;
+        broadcastPlaybackEvent();
+      }.toJS,
+    );
     _audioElement.addEventListener(
-        'error',
-        (Event event) {
-          _eventController.addError(PlatformException(
+      'error',
+      (Event event) {
+        _eventController.addError(
+          PlatformException(
             code: '${_audioElement.error!.code}',
             message: _audioElement.error!.message,
-          ));
-          errorCode = _audioElement.error!.code;
-          errorMessage = _audioElement.error!.message;
-          transition(ProcessingStateMessage.idle);
-          _durationCompleter?.completeError(_audioElement.error!);
-          _durationCompleter = null;
-        }.toJS);
+          ),
+        );
+        errorCode = _audioElement.error!.code;
+        errorMessage = _audioElement.error!.message;
+        transition(ProcessingStateMessage.idle);
+        _durationCompleter?.completeError(_audioElement.error!);
+        _durationCompleter = null;
+      }.toJS,
+    );
     _audioElement.addEventListener(
-        'ended',
-        (Event event) {
-          _currentAudioSourcePlayer?.complete().catchError((e, st) {});
-        }.toJS);
+      'ended',
+      (Event event) {
+        _currentAudioSourcePlayer?.complete().catchError((e, st) {});
+      }.toJS,
+    );
     _audioElement.addEventListener(
-        'timeupdate',
-        (Event event) {
-          _currentAudioSourcePlayer
-              ?.timeUpdated(_audioElement.currentTime.toDouble());
-        }.toJS);
+      'timeupdate',
+      (Event event) {
+        _currentAudioSourcePlayer?.timeUpdated(
+          _audioElement.currentTime.toDouble(),
+        );
+      }.toJS,
+    );
     _audioElement.addEventListener(
-        'loadstart',
-        (Event event) {
-          transition(ProcessingStateMessage.buffering);
-        }.toJS);
+      'loadstart',
+      (Event event) {
+        transition(ProcessingStateMessage.buffering);
+      }.toJS,
+    );
     _audioElement.addEventListener(
-        'waiting',
-        (Event event) {
-          transition(ProcessingStateMessage.buffering);
-        }.toJS);
+      'waiting',
+      (Event event) {
+        transition(ProcessingStateMessage.buffering);
+      }.toJS,
+    );
     _audioElement.addEventListener(
-        'stalled',
-        (Event event) {
-          transition(ProcessingStateMessage.buffering);
-        }.toJS);
+      'stalled',
+      (Event event) {
+        transition(ProcessingStateMessage.buffering);
+      }.toJS,
+    );
     _audioElement.addEventListener(
-        'canplaythrough',
-        (Event event) {
-          _audioElement.playbackRate = _speed;
-          transition(ProcessingStateMessage.ready);
-        }.toJS);
+      'canplaythrough',
+      (Event event) {
+        _audioElement.playbackRate = _speed;
+        transition(ProcessingStateMessage.ready);
+      }.toJS,
+    );
     _audioElement.addEventListener(
-        'progress',
-        (Event event) {
-          broadcastPlaybackEvent();
-        }.toJS);
+      'progress',
+      (Event event) {
+        broadcastPlaybackEvent();
+      }.toJS,
+    );
+  }
+
+  /// Initializes HLS handling for the given [uri].
+  /// @param uri The URI of the audio source.
+  /// @return A [Future] that completes with a boolean indicating whether HLS handling was initialized.
+  /// True if HLS handling was initialized, false otherwise.
+  Future<bool> initializeHlsHandling(String uri) async {
+    if (await shouldUseHlsLibrary(uri)) {
+      try {
+        _hls = Hls(
+          HlsConfig(
+            debug: true.toJS, // Enable debug logging in HLS.js
+            xhrSetup:
+                ((JSObject xhr, String _) {
+                  return;
+                  // if (headers.isEmpty) {
+                  //   return;
+                  // }
+
+                  // if (headers.containsKey('useCookies')) {
+                  //   xhr.withCredentials = true;
+                  // }
+                  // headers.forEach((String key, String value) {
+                  //   if (key != 'useCookies') {
+                  //     xhr.setRequestHeader(key, value);
+                  //   }
+                  // });
+                }).toJS,
+          ),
+        );
+
+        _hls!.on(
+          'hlsError',
+          ((JSObject _, JSObject data) {
+            final HlsError _data = HlsError(data);
+            if (_data.fatal) {
+              _eventController.addError(
+                PlatformException(
+                  code: kErrorValueToErrorName[2]!,
+                  message: _data.type,
+                  details: _data.details,
+                ),
+              );
+            }
+          }).toJS,
+        );
+        _audioElement.onCanPlay.listen((dynamic _) {
+          _durationCompleter?.complete();
+        });
+        _hls!.loadSource(uri);
+        _hls!.attachMedia(_audioElement);
+      } catch (e) {
+        throw NoScriptTagException();
+      }
+      return true;
+    }
+    return false;
+  }
+
+  // HLS support check methods (similar to VideoPlayer class)
+  bool canPlayHlsNatively() {
+    bool canPlayHls = false;
+    try {
+      final String canPlayType = _audioElement.canPlayType(
+        'application/vnd.apple.mpegurl',
+      );
+      canPlayHls = canPlayType != '';
+    } catch (e) {}
+    return canPlayHls;
+  }
+
+  Future<bool> shouldUseHlsLibrary(String uri) async {
+    return isSupported() && (uri.contains('m3u8')) && !canPlayHlsNatively();
   }
 
   /// The current playback order, depending on whether shuffle mode is enabled.
@@ -260,11 +358,13 @@ class Html5AudioPlayer extends JustAudioPlayer {
     _currentAudioSourcePlayer?.pause();
     _audioSourcePlayer = getAudioSource(request.audioSourceMessage);
     _index = request.initialIndex ?? 0;
-    final duration = await _currentAudioSourcePlayer!
-        .load(request.initialPosition?.inMilliseconds);
+    final duration = await _currentAudioSourcePlayer!.load(
+      request.initialPosition?.inMilliseconds,
+    );
     if (request.initialPosition != null) {
-      await _currentAudioSourcePlayer!
-          .seek(request.initialPosition!.inMilliseconds);
+      await _currentAudioSourcePlayer!.seek(
+        request.initialPosition!.inMilliseconds,
+      );
     }
     if (_playing) {
       _currentAudioSourcePlayer!.play();
@@ -275,15 +375,35 @@ class Html5AudioPlayer extends JustAudioPlayer {
   /// Loads audio from [uri] and returns the duration of the loaded audio if
   /// known.
   Future<Duration?> loadUri(
-      final Uri uri, final Duration? initialPosition) async {
+    final Uri uri,
+    final Duration? initialPosition,
+  ) async {
     transition(ProcessingStateMessage.loading);
     final src = uri.toString();
     if (src != _audioElement.src) {
+      // Reset the HLS handling if the previous source was HLS.
+      if (_hls != null) {
+        _hls?.stopLoad();
+        _hls = null;
+      }
+
       _durationCompleter = Completer<dynamic>();
+      _audioElement.id = 'audioPlayer-$id';
       _audioElement.src = src;
       _audioElement.playbackRate = _speed;
       _audioElement.preload = 'auto';
-      await _audioElementQueue.load();
+      ui_web.platformViewRegistry.registerViewFactory(
+        'audioPlayer-$id',
+        (int viewId) => _audioElement,
+      );
+
+      if (await initializeHlsHandling(src)) {
+        // handled in function
+      } else {
+        // normal audio
+        await _audioElementQueue.load();
+      }
+
       if (initialPosition != null) {
         _audioElement.currentTime = initialPosition.inMilliseconds / 1000.0;
       }
@@ -291,7 +411,9 @@ class Html5AudioPlayer extends JustAudioPlayer {
         await _durationCompleter!.future;
       } on MediaError catch (e) {
         throw PlatformException(
-            code: "${e.code}", message: "Failed to load URL");
+          code: "${e.code}",
+          message: "Failed to load URL",
+        );
       } finally {
         _durationCompleter = null;
       }
@@ -343,14 +465,16 @@ class Html5AudioPlayer extends JustAudioPlayer {
 
   @override
   Future<SetShuffleModeResponse> setShuffleMode(
-      SetShuffleModeRequest request) async {
+    SetShuffleModeRequest request,
+  ) async {
     _shuffleModeEnabled = request.shuffleMode == ShuffleModeMessage.all;
     return SetShuffleModeResponse();
   }
 
   @override
   Future<SetShuffleOrderResponse> setShuffleOrder(
-      SetShuffleOrderRequest request) async {
+    SetShuffleOrderRequest request,
+  ) async {
     void internalSetShuffleOrder(AudioSourceMessage sourceMessage) {
       final audioSourcePlayer = _audioSourcePlayers[sourceMessage.id];
       if (audioSourcePlayer == null) return;
@@ -371,11 +495,13 @@ class Html5AudioPlayer extends JustAudioPlayer {
 
   @override
   Future<SetWebCrossOriginResponse> setWebCrossOrigin(
-      SetWebCrossOriginRequest request) async {
-    _audioElement.crossOrigin = const {
-      WebCrossOriginMessage.anonymous: 'anonymous',
-      WebCrossOriginMessage.useCredentials: 'use-credentials',
-    }[request.crossOrigin];
+    SetWebCrossOriginRequest request,
+  ) async {
+    _audioElement.crossOrigin =
+        const {
+          WebCrossOriginMessage.anonymous: 'anonymous',
+          WebCrossOriginMessage.useCredentials: 'use-credentials',
+        }[request.crossOrigin];
     return SetWebCrossOriginResponse();
   }
 
@@ -411,11 +537,13 @@ class Html5AudioPlayer extends JustAudioPlayer {
 
   @override
   Future<ConcatenatingInsertAllResponse> concatenatingInsertAll(
-      ConcatenatingInsertAllRequest request) async {
+    ConcatenatingInsertAllRequest request,
+  ) async {
     final wasNotEmpty = _audioSourcePlayer?.sequence.isNotEmpty ?? false;
     _concatenating(request.id)!.setShuffleOrder(request.shuffleOrder);
-    _concatenating(request.id)!
-        .insertAll(request.index, getAudioSources(request.children));
+    _concatenating(
+      request.id,
+    )!.insertAll(request.index, getAudioSources(request.children));
     if (_index != null && wasNotEmpty && request.index <= _index!) {
       _index = _index! + request.children.length;
     }
@@ -426,7 +554,8 @@ class Html5AudioPlayer extends JustAudioPlayer {
 
   @override
   Future<ConcatenatingRemoveRangeResponse> concatenatingRemoveRange(
-      ConcatenatingRemoveRangeRequest request) async {
+    ConcatenatingRemoveRangeRequest request,
+  ) async {
     if (_index != null &&
         _index! >= request.startIndex &&
         _index! < request.endIndex &&
@@ -435,8 +564,9 @@ class Html5AudioPlayer extends JustAudioPlayer {
       _currentAudioSourcePlayer!.pause();
     }
     _concatenating(request.id)!.setShuffleOrder(request.shuffleOrder);
-    _concatenating(request.id)!
-        .removeRange(request.startIndex, request.endIndex);
+    _concatenating(
+      request.id,
+    )!.removeRange(request.startIndex, request.endIndex);
     if (_index != null) {
       if (_index! >= request.startIndex && _index! < request.endIndex) {
         // Skip backward if there's nothing after this
@@ -464,7 +594,8 @@ class Html5AudioPlayer extends JustAudioPlayer {
 
   @override
   Future<ConcatenatingMoveResponse> concatenatingMove(
-      ConcatenatingMoveRequest request) async {
+    ConcatenatingMoveRequest request,
+  ) async {
     _concatenating(request.id)!.setShuffleOrder(request.shuffleOrder);
     _concatenating(request.id)!.move(request.currentIndex, request.newIndex);
     if (_index != null) {
@@ -484,28 +615,31 @@ class Html5AudioPlayer extends JustAudioPlayer {
 
   @override
   Future<SetAndroidAudioAttributesResponse> setAndroidAudioAttributes(
-      SetAndroidAudioAttributesRequest request) async {
+    SetAndroidAudioAttributesRequest request,
+  ) async {
     return SetAndroidAudioAttributesResponse();
   }
 
   @override
   Future<SetAutomaticallyWaitsToMinimizeStallingResponse>
-      setAutomaticallyWaitsToMinimizeStalling(
-          SetAutomaticallyWaitsToMinimizeStallingRequest request) async {
+  setAutomaticallyWaitsToMinimizeStalling(
+    SetAutomaticallyWaitsToMinimizeStallingRequest request,
+  ) async {
     return SetAutomaticallyWaitsToMinimizeStallingResponse();
   }
 
   @override
   Future<SetCanUseNetworkResourcesForLiveStreamingWhilePausedResponse>
-      setCanUseNetworkResourcesForLiveStreamingWhilePaused(
-          SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest
-              request) async {
+  setCanUseNetworkResourcesForLiveStreamingWhilePaused(
+    SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest request,
+  ) async {
     return SetCanUseNetworkResourcesForLiveStreamingWhilePausedResponse();
   }
 
   @override
   Future<SetPreferredPeakBitRateResponse> setPreferredPeakBitRate(
-      SetPreferredPeakBitRateRequest request) async {
+    SetPreferredPeakBitRateRequest request,
+  ) async {
     return SetPreferredPeakBitRateResponse();
   }
 
@@ -525,6 +659,7 @@ class Html5AudioPlayer extends JustAudioPlayer {
     _currentAudioSourcePlayer?.pause();
     await _audioElementQueue.removeAttribute('src');
     await _audioElementQueue.load();
+    _hls?.stopLoad();
     transition(ProcessingStateMessage.idle);
     return await super.release();
   }
@@ -548,31 +683,49 @@ class Html5AudioPlayer extends JustAudioPlayer {
   /// Converts an audio source message to a player.
   AudioSourcePlayer decodeAudioSource(AudioSourceMessage audioSourceMessage) {
     if (audioSourceMessage is ProgressiveAudioSourceMessage) {
-      return ProgressiveAudioSourcePlayer(this, audioSourceMessage.id,
-          Uri.parse(audioSourceMessage.uri), audioSourceMessage.headers);
+      return ProgressiveAudioSourcePlayer(
+        this,
+        audioSourceMessage.id,
+        Uri.parse(audioSourceMessage.uri),
+        audioSourceMessage.headers,
+      );
     } else if (audioSourceMessage is DashAudioSourceMessage) {
-      return DashAudioSourcePlayer(this, audioSourceMessage.id,
-          Uri.parse(audioSourceMessage.uri), audioSourceMessage.headers);
+      return DashAudioSourcePlayer(
+        this,
+        audioSourceMessage.id,
+        Uri.parse(audioSourceMessage.uri),
+        audioSourceMessage.headers,
+      );
     } else if (audioSourceMessage is HlsAudioSourceMessage) {
-      return HlsAudioSourcePlayer(this, audioSourceMessage.id,
-          Uri.parse(audioSourceMessage.uri), audioSourceMessage.headers);
+      return HlsAudioSourcePlayer(
+        this,
+        audioSourceMessage.id,
+        Uri.parse(audioSourceMessage.uri),
+        audioSourceMessage.headers,
+      );
     } else if (audioSourceMessage is ConcatenatingAudioSourceMessage) {
       return ConcatenatingAudioSourcePlayer(
-          this,
-          audioSourceMessage.id,
-          getAudioSources(audioSourceMessage.children),
-          audioSourceMessage.useLazyPreparation,
-          audioSourceMessage.shuffleOrder);
+        this,
+        audioSourceMessage.id,
+        getAudioSources(audioSourceMessage.children),
+        audioSourceMessage.useLazyPreparation,
+        audioSourceMessage.shuffleOrder,
+      );
     } else if (audioSourceMessage is ClippingAudioSourceMessage) {
       return ClippingAudioSourcePlayer(
-          this,
-          audioSourceMessage.id,
-          getAudioSource(audioSourceMessage.child) as UriAudioSourcePlayer,
-          audioSourceMessage.start,
-          audioSourceMessage.end);
+        this,
+        audioSourceMessage.id,
+        getAudioSource(audioSourceMessage.child) as UriAudioSourcePlayer,
+        audioSourceMessage.start,
+        audioSourceMessage.end,
+      );
     } else if (audioSourceMessage is LoopingAudioSourceMessage) {
-      return LoopingAudioSourcePlayer(this, audioSourceMessage.id,
-          getAudioSource(audioSourceMessage.child), audioSourceMessage.count);
+      return LoopingAudioSourcePlayer(
+        this,
+        audioSourceMessage.id,
+        getAudioSource(audioSourceMessage.child),
+        audioSourceMessage.count,
+      );
     } else {
       throw Exception("Unknown AudioSource type: $audioSourceMessage");
     }
@@ -599,7 +752,7 @@ abstract class AudioSourcePlayer {
 /// A player for an [IndexedAudioSourceMessage].
 abstract class IndexedAudioSourcePlayer extends AudioSourcePlayer {
   IndexedAudioSourcePlayer(Html5AudioPlayer html5AudioPlayer, String id)
-      : super(html5AudioPlayer, id);
+    : super(html5AudioPlayer, id);
 
   /// Loads the audio for the underlying audio source.
   Future<Duration?> load([int? initialPosition]);
@@ -651,8 +804,11 @@ abstract class UriAudioSourcePlayer extends IndexedAudioSourcePlayer {
   int? _initialPos;
 
   UriAudioSourcePlayer(
-      Html5AudioPlayer html5AudioPlayer, String id, this.uri, this.headers)
-      : super(html5AudioPlayer, id);
+    Html5AudioPlayer html5AudioPlayer,
+    String id,
+    this.uri,
+    this.headers,
+  ) : super(html5AudioPlayer, id);
 
   @override
   List<IndexedAudioSourcePlayer> get sequence => [this];
@@ -665,10 +821,9 @@ abstract class UriAudioSourcePlayer extends IndexedAudioSourcePlayer {
     _initialPos = initialPosition;
     _resumePos = (initialPosition ?? 0) / 1000.0;
     _duration = await html5AudioPlayer.loadUri(
-        uri,
-        initialPosition != null
-            ? Duration(milliseconds: initialPosition)
-            : null);
+      uri,
+      initialPosition != null ? Duration(milliseconds: initialPosition) : null,
+    );
     _initialPos = null;
     return _duration;
   }
@@ -726,10 +881,11 @@ abstract class UriAudioSourcePlayer extends IndexedAudioSourcePlayer {
   Duration get bufferedPosition {
     if (_audioElement.buffered.length > 0) {
       return Duration(
-          milliseconds:
-              (_audioElement.buffered.end(_audioElement.buffered.length - 1) *
-                      1000)
-                  .toInt());
+        milliseconds:
+            (_audioElement.buffered.end(_audioElement.buffered.length - 1) *
+                    1000)
+                .toInt(),
+      );
     } else {
       return Duration.zero;
     }
@@ -738,23 +894,32 @@ abstract class UriAudioSourcePlayer extends IndexedAudioSourcePlayer {
 
 /// A player for a [ProgressiveAudioSourceMessage].
 class ProgressiveAudioSourcePlayer extends UriAudioSourcePlayer {
-  ProgressiveAudioSourcePlayer(Html5AudioPlayer html5AudioPlayer, String id,
-      Uri uri, Map<String, String>? headers)
-      : super(html5AudioPlayer, id, uri, headers);
+  ProgressiveAudioSourcePlayer(
+    Html5AudioPlayer html5AudioPlayer,
+    String id,
+    Uri uri,
+    Map<String, String>? headers,
+  ) : super(html5AudioPlayer, id, uri, headers);
 }
 
 /// A player for a [DashAudioSourceMessage].
 class DashAudioSourcePlayer extends UriAudioSourcePlayer {
-  DashAudioSourcePlayer(Html5AudioPlayer html5AudioPlayer, String id, Uri uri,
-      Map<String, String>? headers)
-      : super(html5AudioPlayer, id, uri, headers);
+  DashAudioSourcePlayer(
+    Html5AudioPlayer html5AudioPlayer,
+    String id,
+    Uri uri,
+    Map<String, String>? headers,
+  ) : super(html5AudioPlayer, id, uri, headers);
 }
 
 /// A player for a [HlsAudioSourceMessage].
 class HlsAudioSourcePlayer extends UriAudioSourcePlayer {
-  HlsAudioSourcePlayer(Html5AudioPlayer html5AudioPlayer, String id, Uri uri,
-      Map<String, String>? headers)
-      : super(html5AudioPlayer, id, uri, headers);
+  HlsAudioSourcePlayer(
+    Html5AudioPlayer html5AudioPlayer,
+    String id,
+    Uri uri,
+    Map<String, String>? headers,
+  ) : super(html5AudioPlayer, id, uri, headers);
 }
 
 /// A player for a [ConcatenatingAudioSourceMessage].
@@ -766,10 +931,14 @@ class ConcatenatingAudioSourcePlayer extends AudioSourcePlayer {
   final bool useLazyPreparation;
   List<int> _shuffleOrder;
 
-  ConcatenatingAudioSourcePlayer(Html5AudioPlayer html5AudioPlayer, String id,
-      this.audioSourcePlayers, this.useLazyPreparation, List<int> shuffleOrder)
-      : _shuffleOrder = shuffleOrder,
-        super(html5AudioPlayer, id);
+  ConcatenatingAudioSourcePlayer(
+    Html5AudioPlayer html5AudioPlayer,
+    String id,
+    this.audioSourcePlayers,
+    this.useLazyPreparation,
+    List<int> shuffleOrder,
+  ) : _shuffleOrder = shuffleOrder,
+      super(html5AudioPlayer, id);
 
   @override
   List<IndexedAudioSourcePlayer> get sequence =>
@@ -819,7 +988,9 @@ class ConcatenatingAudioSourcePlayer extends AudioSourcePlayer {
   /// Moves a child player from [currentIndex] to [newIndex].
   void move(int currentIndex, int newIndex) {
     audioSourcePlayers.insert(
-        newIndex, audioSourcePlayers.removeAt(currentIndex));
+      newIndex,
+      audioSourcePlayers.removeAt(currentIndex),
+    );
   }
 }
 
@@ -833,9 +1004,13 @@ class ClippingAudioSourcePlayer extends IndexedAudioSourcePlayer {
   Duration? _duration;
   int? _initialPos;
 
-  ClippingAudioSourcePlayer(Html5AudioPlayer html5AudioPlayer, String id,
-      this.audioSourcePlayer, this.start, this.end)
-      : super(html5AudioPlayer, id);
+  ClippingAudioSourcePlayer(
+    Html5AudioPlayer html5AudioPlayer,
+    String id,
+    this.audioSourcePlayer,
+    this.start,
+    this.end,
+  ) : super(html5AudioPlayer, id);
 
   @override
   List<IndexedAudioSourcePlayer> get sequence => [this];
@@ -852,17 +1027,24 @@ class ClippingAudioSourcePlayer extends IndexedAudioSourcePlayer {
     final absoluteInitialPosition =
         effectiveStart.inMilliseconds + initialPosition;
     _resumePos = absoluteInitialPosition / 1000.0;
-    final fullDuration = (await html5AudioPlayer.loadUri(audioSourcePlayer.uri,
-        Duration(milliseconds: absoluteInitialPosition)));
+    final fullDuration = (await html5AudioPlayer.loadUri(
+      audioSourcePlayer.uri,
+      Duration(milliseconds: absoluteInitialPosition),
+    ));
     _initialPos = null;
     if (fullDuration != null) {
       _duration = Duration(
-          milliseconds: min((end ?? fullDuration).inMilliseconds,
-                  fullDuration.inMilliseconds) -
-              effectiveStart.inMilliseconds);
+        milliseconds:
+            min(
+              (end ?? fullDuration).inMilliseconds,
+              fullDuration.inMilliseconds,
+            ) -
+            effectiveStart.inMilliseconds,
+      );
     } else if (end != null) {
       _duration = Duration(
-          milliseconds: end!.inMilliseconds - effectiveStart.inMilliseconds);
+        milliseconds: end!.inMilliseconds - effectiveStart.inMilliseconds,
+      );
     }
     return _duration;
   }
@@ -934,8 +1116,9 @@ class ClippingAudioSourcePlayer extends IndexedAudioSourcePlayer {
   @override
   Duration get bufferedPosition {
     if (_audioElement.buffered.length > 0) {
-      var seconds =
-          _audioElement.buffered.end(_audioElement.buffered.length - 1);
+      var seconds = _audioElement.buffered.end(
+        _audioElement.buffered.length - 1,
+      );
       var position = Duration(milliseconds: (seconds * 1000).toInt());
       position -= effectiveStart;
       if (position < Duration.zero) {
@@ -968,15 +1151,19 @@ class LoopingAudioSourcePlayer extends AudioSourcePlayer {
   /// The number of times to loop.
   final int count;
 
-  LoopingAudioSourcePlayer(Html5AudioPlayer html5AudioPlayer, String id,
-      this.audioSourcePlayer, this.count)
-      : super(html5AudioPlayer, id);
+  LoopingAudioSourcePlayer(
+    Html5AudioPlayer html5AudioPlayer,
+    String id,
+    this.audioSourcePlayer,
+    this.count,
+  ) : super(html5AudioPlayer, id);
 
   @override
   List<IndexedAudioSourcePlayer> get sequence =>
-      List.generate(count, (i) => audioSourcePlayer)
-          .expand((p) => p.sequence)
-          .toList();
+      List.generate(
+        count,
+        (i) => audioSourcePlayer,
+      ).expand((p) => p.sequence).toList();
 
   @override
   List<int> get shuffleIndices {
@@ -1010,8 +1197,9 @@ class _AudioElementQueue {
   }
 
   Future<void> removeAttribute(String qualifiedName) {
-    return _lock
-        .synchronized(() => audioElement.removeAttribute(qualifiedName));
+    return _lock.synchronized(
+      () => audioElement.removeAttribute(qualifiedName),
+    );
   }
 
   Future<JSAny?> setSinkId(String sinkId) {

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: just_audio_web
 description: Web platform implementation of just_audio. This implementation is endorsed and therefore doesn't require a direct dependency.
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_web
-version: 0.4.16
+version: 0.4.17
 
 flutter:
   plugin:

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -25,5 +25,5 @@ dev_dependencies:
   flutter_lints: ^2.0.1
 
 environment:
-  sdk: ^3.2.1
-  flutter: '>=3.16.0'
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: ">=3.16.0"


### PR DESCRIPTION
Hi, thanks for maintaining this great library.

I needed HLS support for a project I'm working on so this change adds support for HLS streams in just_audio_web based on the work done by liorshk as discussed in issue [#242](https://github.com/ryanheise/just_audio/issues/242).

This utilizes HLS.JS for playback, added note in README.md on the script tag that needs to be added to fetch that library if HLS playback is desired.