### PR TITLE
Fix bug by syncing ExoPlayer shuffleOrder on setShuffleOrder (Closes #1551)

### DIFF
--- a/just_audio/CHANGELOG.md
+++ b/just_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.6
+
+* Fix bug where ExoPlayer's auto-advance ignores new shuffle order
+
 ## 0.10.5
 
 * Disable Android audio offload by default to prevent playback issues.

--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
@@ -583,11 +583,13 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
         Map<?, ?> map = (Map<?, ?>)json;
         String id = mapGet(map, "id");
         MediaSource mediaSource = mediaSources.get(id);
+        ShuffleOrder shuffleOrder = decodeShuffleOrder(mapGet(map, "shuffleOrder"));
+        player.setShuffleOrder(shuffleOrder);
         if (mediaSource == null) return;
         switch ((String)mapGet(map, "type")) {
         case "concatenating":
             androidx.media3.exoplayer.source.ConcatenatingMediaSource concatenatingMediaSource = (androidx.media3.exoplayer.source.ConcatenatingMediaSource)mediaSource;
-            concatenatingMediaSource.setShuffleOrder(decodeShuffleOrder(mapGet(map, "shuffleOrder")));
+            concatenatingMediaSource.setShuffleOrder(shuffleOrder);
             List<Object> children = mapGet(map, "children");
             for (Object child : children) {
                 setShuffleOrder(child);

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and sequence any sound from any source (asset/file/URL/stream) in gapless playlists.
-version: 0.10.5
+version: 0.10.6
 repository: https://github.com/ryanheise/just_audio/tree/minor/just_audio
 issue_tracker: https://github.com/ryanheise/just_audio/issues
 topics:


### PR DESCRIPTION
This pull request solves Issue #1551.
**Warning**: Not thoroughly tested yet, but since effectively only 1 line has been changed, this should not take long.