### PR TITLE
Fix RangeError in shuffleIndices caused by shared mutable list reference

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -3211,7 +3211,7 @@ class ConcatenatingAudioSource extends AudioSource {
       id: _id,
       children: children.map((child) => child._toMessage()).toList(),
       useLazyPreparation: useLazyPreparation,
-      shuffleOrder: _shuffleOrder.indices);
+      shuffleOrder: List.of(_shuffleOrder.indices));
 }
 
 /// An [AudioSource] that clips the audio of a [UriAudioSource] between a

--- a/just_audio/test/just_audio_test.dart
+++ b/just_audio/test/just_audio_test.dart
@@ -1056,6 +1056,103 @@ void runTests() {
     await player2.dispose();
   });
 
+  test('_toMessage should copy shuffleOrder to prevent shared mutation',
+      () async {
+    final source = ConcatenatingAudioSource(
+      shuffleOrder: DefaultShuffleOrder(random: Random(1001)),
+      children: [
+        AudioSource.uri(Uri.parse("https://foo.foo/a.mp3"), tag: 'a'),
+        AudioSource.uri(Uri.parse("https://foo.foo/b.mp3"), tag: 'b'),
+        AudioSource.uri(Uri.parse("https://foo.foo/c.mp3"), tag: 'c'),
+      ],
+    );
+    final player = AudioPlayer();
+    await player.setAudioSource(source);
+    final msg = mock.mostRecentPlayer!.loadedPlaylist!.children.first
+        as ConcatenatingAudioSourceMessage;
+
+    expect(msg.children.length, equals(3));
+    expect(msg.shuffleOrder.length, equals(3));
+
+    await source.insert(
+        3, AudioSource.uri(Uri.parse("https://foo.foo/d.mp3"), tag: 'd'));
+
+    expect(msg.shuffleOrder.length, equals(3),
+        reason: 'shuffleOrder should be a defensive copy, not mutated by insert');
+    expect(msg.children.length, equals(3));
+    expect(msg.shuffleOrder.length, equals(msg.children.length),
+        reason: 'shuffleOrder and children should stay in sync');
+
+    await player.dispose();
+  });
+
+  test(
+      'desync\'d shuffleOrder causes RangeError in shuffleIndices computation',
+      () {
+    final shuffleOrder = <int>[2, 0, 1];
+    final msg = ConcatenatingAudioSourceMessage(
+      id: 'test-cat',
+      children: [
+        ProgressiveAudioSourceMessage(
+            id: 'a', uri: 'https://foo/a.mp3', headers: null, tag: null),
+        ProgressiveAudioSourceMessage(
+            id: 'b', uri: 'https://foo/b.mp3', headers: null, tag: null),
+        ProgressiveAudioSourceMessage(
+            id: 'c', uri: 'https://foo/c.mp3', headers: null, tag: null),
+      ],
+      useLazyPreparation: true,
+      shuffleOrder: shuffleOrder,
+    );
+
+    expect(computeShuffleIndices(msg), equals([2, 0, 1]));
+
+    shuffleOrder.add(3);
+
+    expect(
+      () => computeShuffleIndices(msg),
+      throwsA(isA<RangeError>()),
+      reason:
+          'shuffleOrder references index 3 but children has only 3 entries',
+    );
+  });
+
+  test('insert should not cause shuffleOrder desync during async gap',
+      () async {
+    final source = ConcatenatingAudioSource(
+      shuffleOrder: DefaultShuffleOrder(random: Random(1001)),
+      children: [
+        AudioSource.uri(Uri.parse("https://foo.foo/a.mp3"), tag: 'a'),
+        AudioSource.uri(Uri.parse("https://foo.foo/b.mp3"), tag: 'b'),
+        AudioSource.uri(Uri.parse("https://foo.foo/c.mp3"), tag: 'c'),
+      ],
+    );
+    final player = AudioPlayer();
+    await player.setAudioSource(source);
+    final msg = mock.mostRecentPlayer!.loadedPlaylist!.children.first
+        as ConcatenatingAudioSourceMessage;
+    mock.mostRecentPlayer!.blockInsert();
+
+    final insertFuture = source.insert(
+        3, AudioSource.uri(Uri.parse("https://foo.foo/d.mp3"), tag: 'd'));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(msg.shuffleOrder.length, equals(3),
+        reason:
+            'shuffleOrder should not be mutated — message holds a defensive copy');
+    expect(msg.shuffleOrder.length, equals(msg.children.length),
+        reason: 'shuffleOrder and children should stay in sync');
+    expect(
+      () => computeShuffleIndices(msg),
+      returnsNormally,
+      reason: 'no desync means no RangeError',
+    );
+
+    mock.mostRecentPlayer!.unblockInsert();
+    await insertFuture;
+    await player.dispose();
+  });
+
+
   test('seekToIndex', () async {
     final source = ConcatenatingAudioSource(
       shuffleOrder: DefaultShuffleOrder(random: Random(1001)),
@@ -1718,6 +1815,30 @@ void runTests() {
   });
 }
 
+/// Replicates the shuffleIndices algorithm from
+/// AudioSourceExtension in just_audio_background (L891-906).
+List<int> computeShuffleIndices(ConcatenatingAudioSourceMessage msg) {
+  var offset = 0;
+  final childIndicesList = <List<int>>[];
+  for (final child in msg.children) {
+    if (child is ConcatenatingAudioSourceMessage) {
+      final childIndices =
+          computeShuffleIndices(child).map((i) => i + offset).toList();
+      childIndicesList.add(childIndices);
+      offset += childIndices.length;
+    } else {
+      childIndicesList.add([offset]);
+      offset += 1;
+    }
+  }
+  final indices = <int>[];
+  for (final index in msg.shuffleOrder) {
+    indices.addAll(childIndicesList[index]);
+  }
+  return indices;
+}
+
+
 class MockJustAudio extends Mock
     with MockPlatformInterfaceMixin
     implements JustAudioPlatform {
@@ -1808,6 +1929,8 @@ class MockAudioPlayer extends AudioPlayerPlatform {
   int? _errorCode;
   String? _errorMessage;
   Completer<void>? _loadBlock;
+  ConcatenatingAudioSourceMessage? loadedPlaylist;
+  Completer<void>? _insertBlock;
 
   MockAudioPlayer(InitRequest request)
       : audioLoadConfiguration = request.audioLoadConfiguration,
@@ -1832,6 +1955,15 @@ class MockAudioPlayer extends AudioPlayerPlatform {
   void unblockLoad() {
     _loadBlock?.complete();
     _loadBlock = null;
+  }
+
+  void blockInsert() {
+    _insertBlock ??= Completer();
+  }
+
+  void unblockInsert() {
+    _insertBlock?.complete();
+    _insertBlock = null;
   }
 
   Future<void> _loadReady() async {
@@ -1859,6 +1991,7 @@ class MockAudioPlayer extends AudioPlayerPlatform {
     final loadRequest = _loadRequest = MockLoadRequest();
     final playlist =
         request.audioSourceMessage as ConcatenatingAudioSourceMessage;
+    loadedPlaylist = playlist;
     if (playlist.children.isEmpty) return LoadResponse(duration: null);
     final audioSource = playlist.children.first;
     _processingState = ProcessingStateMessage.loading;
@@ -2018,7 +2151,9 @@ class MockAudioPlayer extends AudioPlayerPlatform {
   @override
   Future<ConcatenatingInsertAllResponse> concatenatingInsertAll(
       ConcatenatingInsertAllRequest request) async {
-    // TODO
+    if (_insertBlock != null) {
+      await _insertBlock!.future;
+    }
     return ConcatenatingInsertAllResponse();
   }
 

--- a/just_audio_background/lib/just_audio_background.dart
+++ b/just_audio_background/lib/just_audio_background.dart
@@ -901,7 +901,9 @@ extension AudioSourceExtension on AudioSourceMessage {
       }
       final indices = <int>[];
       for (final index in self.shuffleOrder) {
-        indices.addAll(childIndicesList[index]);
+        if (index < childIndicesList.length) {
+          indices.addAll(childIndicesList[index]);
+        }
       }
       return indices;
     } else if (self is LoopingAudioSourceMessage) {

--- a/just_audio_background/pubspec.yaml
+++ b/just_audio_background/pubspec.yaml
@@ -23,6 +23,8 @@ dependencies:
   synchronized: ^3.3.0+3
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   flutter_lints: ^2.0.1
 
 environment:

--- a/just_audio_background/test/shuffle_indices_test.dart
+++ b/just_audio_background/test/shuffle_indices_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio_background/just_audio_background.dart';
+import 'package:just_audio_platform_interface/just_audio_platform_interface.dart';
+
+ProgressiveAudioSourceMessage _uri(String id) =>
+    ProgressiveAudioSourceMessage(id: id, uri: 'https://$id.mp3');
+
+ConcatenatingAudioSourceMessage _concat({
+  required List<AudioSourceMessage> children,
+  required List<int> shuffleOrder,
+}) =>
+    ConcatenatingAudioSourceMessage(
+      id: 'cat',
+      children: children,
+      useLazyPreparation: true,
+      shuffleOrder: shuffleOrder,
+    );
+
+void main() {
+  test('shuffleIndices returns correct indices for synced shuffleOrder', () {
+    final source = _concat(
+      children: [_uri('a'), _uri('b'), _uri('c')],
+      shuffleOrder: [2, 0, 1],
+    );
+
+    expect(source.shuffleIndices, [2, 0, 1]);
+  });
+
+  test('shuffleIndices skips out-of-bounds indices in shuffleOrder', () {
+    final source = _concat(
+      children: [_uri('a'), _uri('b')],
+      shuffleOrder: [1, 0, 2],
+    );
+
+    expect(source.shuffleIndices, [1, 0]);
+  });
+
+  test('shuffleIndices handles all indices out of bounds', () {
+    final source = _concat(
+      children: [_uri('a')],
+      shuffleOrder: [3, 5, 7],
+    );
+
+    expect(source.shuffleIndices, isEmpty);
+  });
+}
+


### PR DESCRIPTION
Fixes #1573

## Problem

`ConcatenatingAudioSource._toMessage()` passes `_shuffleOrder.indices` **by reference** into `ConcatenatingAudioSourceMessage`. This means the background handler (`just_audio_background`) and the frontend (`just_audio`) share the same `List<int>` object.

When `insert()` is called, it mutates `_shuffleOrder` synchronously — but the platform request to update `children` happens *after* an `await` yield. During that async gap, the background handler sees a `shuffleOrder` that already reflects the new size while `children` still has the old size. The `shuffleIndices` getter then indexes into `childIndicesList` with an out-of-bounds value, causing a `RangeError`.

Notably, `ConcatenatingInsertAllRequest` already copies correctly with `List.of(_shuffleOrder.indices)`, and `_toMessage()` also copies `children` via `.toList()` — only the `shuffleOrder` field was missing the defensive copy.

### Crashlytics stacktrace

```
RangeError (length): Invalid value: Not in inclusive range 0..N: N+1
```

Crash site: `just_audio_background.dart:896` → `AudioSourceExtension.shuffleIndices`

```dart
List<int> get shuffleIndices {
  final self = this;
  if (self is ConcatenatingAudioSourceMessage) {
    var offset = 0;
    final childIndicesList = <List<int>>[];
    for (final child in self.children) {        // N children → N entries
      childIndicesList.add(child.shuffleIndices.map((i) => i + offset).toList());
      offset += childIndices.length;
    }
    for (final index in self.shuffleOrder) {    // shuffleOrder has value N
      indices.addAll(childIndicesList[index]);   // 💥 childIndicesList[N] → RangeError
    }
  }
}
```

Two crash paths observed:

**Path A — Playlist load:**
```
setAudioSources → load → _setPlatformActive.setPlatform
  → setShuffleMode → _updateShuffleIndices → shuffleIndices → 💥
```

**Path B — Live queue mutation (e.g. inserting a track):**
```
ConcatenatingAudioSource.insert → _setPlatformActive.setPlatform
  → setShuffleMode → _updateShuffleIndices → shuffleIndices → 💥
```

The mismatch is exactly ±1 in every observed crash (e.g., `0..498:499`, `0..103:104`), matching exactly one item being inserted or removed — `children` count changes by 1 while `shuffleOrder` isn't atomically updated.

## Changes

### Fix 1 — Root cause (`just_audio`)

Copy the list in `_toMessage()` so the background handler gets its own snapshot:

```dart
shuffleOrder: List.of(_shuffleOrder.indices)
```

This breaks the shared mutable reference. The background handler's `shuffleOrder` and `children` now stay consistent regardless of what the frontend does after the message is created.

### Fix 2 — Defensive bounds check (`just_audio_background`)

Add a guard in the `shuffleIndices` getter so it skips invalid indices instead of crashing:

```dart
for (final index in self.shuffleOrder) {
  if (index < childIndicesList.length) {
    indices.addAll(childIndicesList[index]);
  }
}
```

This is a safety net — Fix 1 prevents the desync, but this ensures `shuffleIndices` can never throw a `RangeError` even if a future code path reintroduces shared state.

## Tests

**`just_audio/test/just_audio_test.dart`** — 3 new tests:
- `_toMessage should copy shuffleOrder to prevent shared mutation` — verifies the message holds a defensive copy, not a shared reference
- `desync'd shuffleOrder causes RangeError in shuffleIndices computation` — proves the algorithm crashes when given desync'd input (the exact Crashlytics scenario)
- `insert should not cause shuffleOrder desync during async gap` — blocks `concatenatingInsertAll` mid-flight and verifies no desync occurs during the async gap

**`just_audio_background/test/shuffle_indices_test.dart`** — 3 new tests:
- `shuffleIndices returns correct indices for synced shuffleOrder` — normal case
- `shuffleIndices skips out-of-bounds indices in shuffleOrder` — verifies the bounds check
- `shuffleIndices handles all indices out of bounds` — edge case, all indices invalid