### PR TITLE
fix(ios): ios 17 pro max simulator encoded url parsing bug

### DIFF
--- a/just_audio/darwin/just_audio.podspec
+++ b/just_audio/darwin/just_audio.podspec
@@ -18,5 +18,8 @@ A flutter plugin for playing audio.
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.14'
+  s.ios.frameworks = 'AVFoundation', 'MobileCoreServices'
+  s.osx.frameworks = 'AVFoundation', 'CoreServices'
+  s.weak_frameworks = 'UniformTypeIdentifiers'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/just_audio/darwin/just_audio/Package.swift
+++ b/just_audio/darwin/just_audio/Package.swift
@@ -19,6 +19,12 @@ let package = Package(
             dependencies: [],
             cSettings: [
                 .headerSearchPath("include/just_audio")
+            ],
+            linkerSettings: [
+                .linkedFramework("AVFoundation"),
+                .linkedFramework("UniformTypeIdentifiers", .when(platforms: [.iOS, .macOS])),
+                .linkedFramework("MobileCoreServices", .when(platforms: [.iOS])),
+                .linkedFramework("CoreServices", .when(platforms: [.macOS]))
             ]
         )
     ]

--- a/just_audio/darwin/just_audio/Sources/just_audio/AudioPlayer.m
+++ b/just_audio/darwin/just_audio/Sources/just_audio/AudioPlayer.m
@@ -992,7 +992,27 @@
 }
 
 - (void)sendErrorForItem:(IndexedPlayerItem *)playerItem {
-    [self sendError:@((int)playerItem.error.code) errorMessage:playerItem.error.localizedDescription playerItem:playerItem switchToIdle:YES];
+    NSString *errorMessage = playerItem.error.localizedDescription;
+    // Log full error chain for diagnostics.
+    NSLog(@"just_audio: AVPlayerItem error: domain=%@ code=%ld desc=%@",
+          playerItem.error.domain, (long)playerItem.error.code, playerItem.error.localizedDescription);
+    NSLog(@"just_audio: AVPlayerItem error userInfo: %@", playerItem.error.userInfo);
+    // Include underlying error details (e.g. iOS 17 AVFoundation / network errors).
+    NSError *underlyingError = playerItem.error.userInfo[NSUnderlyingErrorKey];
+    while (underlyingError) {
+        NSLog(@"just_audio:   Underlying error: domain=%@ code=%ld desc=%@",
+              underlyingError.domain, (long)underlyingError.code, underlyingError.localizedDescription);
+        errorMessage = [NSString stringWithFormat:@"%@ (underlying: %@ %ld - %@)",
+                        errorMessage, underlyingError.domain, (long)underlyingError.code,
+                        underlyingError.localizedDescription];
+        underlyingError = underlyingError.userInfo[NSUnderlyingErrorKey];
+    }
+    // Include the failing URL if available.
+    NSURL *failingURL = playerItem.error.userInfo[NSURLErrorFailingURLErrorKey];
+    if (failingURL) {
+        NSLog(@"just_audio:   Failing URL: %@", [failingURL absoluteString]);
+    }
+    [self sendError:@((int)playerItem.error.code) errorMessage:errorMessage playerItem:playerItem switchToIdle:YES];
     [_player removeAllItems];
 }
 

--- a/just_audio/darwin/just_audio/Sources/just_audio/ResourceLoaderDelegate.m
+++ b/just_audio/darwin/just_audio/Sources/just_audio/ResourceLoaderDelegate.m
@@ -1,0 +1,261 @@
+#import "./include/just_audio/ResourceLoaderDelegate.h"
+#include <TargetConditionals.h>
+
+#if __has_include(<UniformTypeIdentifiers/UniformTypeIdentifiers.h>)
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#endif
+
+#if TARGET_OS_IPHONE
+#import <MobileCoreServices/MobileCoreServices.h>
+#else
+#import <CoreServices/CoreServices.h>
+#endif
+
+static NSString *const kCustomSchemePrefix = @"just-audio-";
+
+@implementation ResourceLoaderDelegate {
+    NSString *_originalURLString;
+    NSDictionary *_headers;
+    NSURLSession *_session;
+    NSMutableArray<NSURLSessionDataTask *> *_pendingTasks;
+}
+
++ (NSString *)customSchemePrefix {
+    return kCustomSchemePrefix;
+}
+
++ (NSString *)interceptedURLString:(NSString *)urlString {
+    if ([urlString hasPrefix:@"https://"]) {
+        return [NSString stringWithFormat:@"%@https://%@", kCustomSchemePrefix, [urlString substringFromIndex:8]];
+    } else if ([urlString hasPrefix:@"http://"]) {
+        return [NSString stringWithFormat:@"%@http://%@", kCustomSchemePrefix, [urlString substringFromIndex:7]];
+    }
+    return urlString;
+}
+
++ (BOOL)isInterceptedURLString:(NSString *)urlString {
+    return [urlString hasPrefix:kCustomSchemePrefix];
+}
+
+/// Restores the original HTTP(S) URL from a custom-scheme URL.
++ (NSString *)restoreURLString:(NSString *)interceptedURLString {
+    if ([interceptedURLString hasPrefix:[NSString stringWithFormat:@"%@https://", kCustomSchemePrefix]]) {
+        return [NSString stringWithFormat:@"https://%@",
+                [interceptedURLString substringFromIndex:kCustomSchemePrefix.length + 8]];
+    } else if ([interceptedURLString hasPrefix:[NSString stringWithFormat:@"%@http://", kCustomSchemePrefix]]) {
+        return [NSString stringWithFormat:@"http://%@",
+                [interceptedURLString substringFromIndex:kCustomSchemePrefix.length + 7]];
+    }
+    return interceptedURLString;
+}
+
+- (instancetype)initWithOriginalURLString:(NSString *)originalURLString headers:(NSDictionary *)headers {
+    self = [super init];
+    if (self) {
+        _originalURLString = [originalURLString copy];
+        _headers = headers;
+        NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+        _session = [NSURLSession sessionWithConfiguration:config];
+        _pendingTasks = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (NSString *)originalURLString {
+    return _originalURLString;
+}
+
+#pragma mark - AVAssetResourceLoaderDelegate
+
+- (BOOL)resourceLoader:(AVAssetResourceLoader *)resourceLoader
+shouldWaitForLoadingOfRequestedResource:(AVAssetResourceLoadingRequest *)loadingRequest {
+    NSURL *requestURL = loadingRequest.request.URL;
+    if (!requestURL) {
+        return NO;
+    }
+
+    // Use the stored original URL string directly to preserve exact percent-encoding.
+    // Do NOT use the requestURL's absoluteString and try to restore it, as that
+    // may have already been normalized by NSURL.
+    NSURL *originalURL = [NSURL URLWithString:_originalURLString];
+    if (!originalURL) {
+        // Fallback: try NSURLComponents for stricter parsing
+        NSURLComponents *components = [NSURLComponents componentsWithString:_originalURLString];
+        originalURL = components.URL;
+    }
+    if (!originalURL) {
+        NSLog(@"just_audio: ResourceLoader: Failed to create URL from original string: %@", _originalURLString);
+        return NO;
+    }
+
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:originalURL];
+    [request setHTTPMethod:@"GET"];
+
+    // Copy custom headers
+    if (_headers && [_headers count] > 0) {
+        for (NSString *key in _headers) {
+            [request setValue:_headers[key] forHTTPHeaderField:key];
+        }
+    }
+
+    // Handle byte-range requests from AVFoundation
+    AVAssetResourceLoadingDataRequest *dataRequest = loadingRequest.dataRequest;
+    if (dataRequest) {
+        long long offset = dataRequest.requestedOffset;
+        long long length = dataRequest.requestedLength;
+        if (dataRequest.currentOffset != 0) {
+            offset = dataRequest.currentOffset;
+            length = dataRequest.requestedLength - (dataRequest.currentOffset - dataRequest.requestedOffset);
+        }
+        if (offset > 0 || !dataRequest.requestsAllDataToEndOfResource) {
+            NSString *rangeValue;
+            if (dataRequest.requestsAllDataToEndOfResource) {
+                rangeValue = [NSString stringWithFormat:@"bytes=%lld-", offset];
+            } else {
+                rangeValue = [NSString stringWithFormat:@"bytes=%lld-%lld", offset, offset + length - 1];
+            }
+            [request setValue:rangeValue forHTTPHeaderField:@"Range"];
+        }
+    }
+
+    NSLog(@"just_audio: ResourceLoader: Loading %@ (Range: %@)",
+          self->_originalURLString,
+          [request valueForHTTPHeaderField:@"Range"] ?: @"full");
+
+    NSURLSessionDataTask *task = [_session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        // Remove this task from pending
+        @synchronized(self->_pendingTasks) {
+            [self->_pendingTasks removeObject:task];
+        }
+
+        if (loadingRequest.isCancelled) {
+            return;
+        }
+
+        if (error) {
+            NSLog(@"just_audio: ResourceLoader: Network error: %@ (code=%ld)", error.localizedDescription, (long)error.code);
+            [loadingRequest finishLoadingWithError:error];
+            return;
+        }
+
+        NSHTTPURLResponse *httpResponse = nil;
+        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+            httpResponse = (NSHTTPURLResponse *)response;
+        }
+
+        if (!httpResponse) {
+            NSLog(@"just_audio: ResourceLoader: Non-HTTP response received");
+            NSError *err = [NSError errorWithDomain:@"just_audio" code:-1
+                                           userInfo:@{NSLocalizedDescriptionKey: @"Non-HTTP response"}];
+            [loadingRequest finishLoadingWithError:err];
+            return;
+        }
+
+        NSInteger statusCode = httpResponse.statusCode;
+        NSLog(@"just_audio: ResourceLoader: Response %ld, Content-Length: %@, Content-Type: %@",
+              (long)statusCode,
+              httpResponse.allHeaderFields[@"Content-Length"] ?: @"unknown",
+              httpResponse.MIMEType ?: @"unknown");
+
+        if (statusCode >= 400) {
+            NSLog(@"just_audio: ResourceLoader: HTTP error %ld for URL: %@", (long)statusCode, self->_originalURLString);
+            NSError *err = [NSError errorWithDomain:@"just_audio" code:statusCode
+                                           userInfo:@{NSLocalizedDescriptionKey:
+                                                          [NSString stringWithFormat:@"HTTP %ld", (long)statusCode]}];
+            [loadingRequest finishLoadingWithError:err];
+            return;
+        }
+
+        // Fill content information if requested
+        AVAssetResourceLoadingContentInformationRequest *contentInfoRequest = loadingRequest.contentInformationRequest;
+        if (contentInfoRequest) {
+            // Set content type (UTI)
+            NSString *mimeType = httpResponse.MIMEType ?: @"audio/mp4";
+            if (@available(iOS 14.0, macOS 11.0, *)) {
+                UTType *utType = [UTType typeWithMIMEType:mimeType];
+                if (utType) {
+                    contentInfoRequest.contentType = utType.identifier;
+                } else {
+                    contentInfoRequest.contentType = @"public.audio";
+                }
+            } else {
+                // Fallback: convert MIME to UTI
+                CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(
+                    kUTTagClassMIMEType,
+                    (__bridge CFStringRef)mimeType,
+                    NULL);
+                if (uti) {
+                    contentInfoRequest.contentType = (__bridge_transfer NSString *)uti;
+                } else {
+                    contentInfoRequest.contentType = @"public.audio";
+                }
+            }
+
+            contentInfoRequest.byteRangeAccessSupported = YES;
+
+            // Determine total content length
+            NSString *contentRange = httpResponse.allHeaderFields[@"Content-Range"];
+            if (contentRange) {
+                // Format: "bytes start-end/total"
+                NSArray *slashParts = [contentRange componentsSeparatedByString:@"/"];
+                if (slashParts.count == 2) {
+                    NSString *totalStr = slashParts[1];
+                    if (![totalStr isEqualToString:@"*"]) {
+                        contentInfoRequest.contentLength = [totalStr longLongValue];
+                    }
+                }
+            } else {
+                // Use Content-Length for non-range responses
+                long long expectedLength = httpResponse.expectedContentLength;
+                if (expectedLength != NSURLResponseUnknownLength && expectedLength > 0) {
+                    contentInfoRequest.contentLength = expectedLength;
+                }
+            }
+        }
+
+        // Provide the data
+        if (data && data.length > 0 && dataRequest) {
+            [dataRequest respondWithData:data];
+        }
+
+        [loadingRequest finishLoading];
+    }];
+
+    // Track for cancellation
+    @synchronized(_pendingTasks) {
+        [_pendingTasks addObject:task];
+    }
+    [task resume];
+
+    return YES;
+}
+
+- (void)resourceLoader:(AVAssetResourceLoader *)resourceLoader
+didCancelLoadingRequest:(AVAssetResourceLoadingRequest *)loadingRequest {
+    @synchronized(_pendingTasks) {
+        // Cancel all pending tasks (simple approach - could be more granular)
+        for (NSURLSessionDataTask *task in [_pendingTasks copy]) {
+            [task cancel];
+        }
+        [_pendingTasks removeAllObjects];
+    }
+}
+
+#pragma mark - Cleanup
+
+- (void)invalidate {
+    @synchronized(_pendingTasks) {
+        for (NSURLSessionDataTask *task in [_pendingTasks copy]) {
+            [task cancel];
+        }
+        [_pendingTasks removeAllObjects];
+    }
+    [_session invalidateAndCancel];
+}
+
+- (void)dealloc {
+    [self invalidate];
+}
+
+@end

--- a/just_audio/darwin/just_audio/Sources/just_audio/UriAudioSource.m
+++ b/just_audio/darwin/just_audio/Sources/just_audio/UriAudioSource.m
@@ -2,6 +2,7 @@
 #import "./include/just_audio/IndexedAudioSource.h"
 #import "./include/just_audio/IndexedPlayerItem.h"
 #import "./include/just_audio/LoadControl.h"
+#import "./include/just_audio/ResourceLoaderDelegate.h"
 #import <AVFoundation/AVFoundation.h>
 
 @implementation UriAudioSource {
@@ -12,6 +13,10 @@
     LoadControl *_loadControl;
     NSMutableDictionary *_headers;
     NSDictionary *_options;
+    // Must keep a strong reference to the delegate, as AVAssetResourceLoader
+    // only holds a weak reference.
+    ResourceLoaderDelegate *_resourceLoaderDelegate;
+    ResourceLoaderDelegate *_resourceLoaderDelegate2;
 }
 
 - (instancetype)initWithId:(NSString *)sid uri:(NSString *)uri loadControl:(LoadControl *)loadControl headers:(NSDictionary *)headers options:(NSDictionary *)options {
@@ -21,7 +26,9 @@
     _loadControl = loadControl;
     _headers = headers != (id)[NSNull null] ? [headers mutableCopy] : nil;
     _options = options;
-    _playerItem = [self createPlayerItem:uri];
+    _resourceLoaderDelegate = nil;
+    _resourceLoaderDelegate2 = nil;
+    _playerItem = [self createPlayerItem:uri storeDelegate:YES isPrimary:YES];
     _playerItem2 = nil;
     return self;
 }
@@ -30,7 +37,7 @@
     return _uri;
 }
 
-- (IndexedPlayerItem *)createPlayerItem:(NSString *)uri {
+- (IndexedPlayerItem *)createPlayerItem:(NSString *)uri storeDelegate:(BOOL)storeDelegate isPrimary:(BOOL)isPrimary {
     IndexedPlayerItem *item;
     NSMutableDictionary *assetOptions = [[NSMutableDictionary alloc] init];
     
@@ -69,8 +76,70 @@
             }
         }
         
-        AVURLAsset *asset = [AVURLAsset URLAssetWithURL:[NSURL URLWithString:uri] options:assetOptions];
-        item = [[IndexedPlayerItem alloc] initWithAsset:asset];
+        // For HTTP(S) URLs, use a custom URL scheme with AVAssetResourceLoaderDelegate
+        // to intercept and handle network requests ourselves via NSURLSession.
+        // This is necessary because iOS 17+ changed the URL parser (RFC 3986) which
+        // normalizes percent-encoded characters (e.g. %2B → +, %3D → =) breaking
+        // signed/verified URLs. By handling requests ourselves, we preserve the
+        // exact URL encoding.
+        BOOL useResourceLoader = [uri hasPrefix:@"http://"] || [uri hasPrefix:@"https://"];
+
+        if (useResourceLoader) {
+            NSString *interceptedURI = [ResourceLoaderDelegate interceptedURLString:uri];
+            NSURL *interceptedURL = [NSURL URLWithString:interceptedURI];
+            if (!interceptedURL) {
+                NSLog(@"just_audio: ResourceLoader: Failed to create intercepted URL from: %@", interceptedURI);
+                // Fallback to direct loading
+                useResourceLoader = NO;
+            } else {
+                ResourceLoaderDelegate *delegate = [[ResourceLoaderDelegate alloc]
+                    initWithOriginalURLString:uri
+                    headers:(_headers && [_headers count] > 0) ? _headers : nil];
+
+                AVURLAsset *asset = [AVURLAsset URLAssetWithURL:interceptedURL options:assetOptions];
+                [asset.resourceLoader setDelegate:delegate queue:dispatch_get_main_queue()];
+
+                // Store a strong reference to the delegate (AVAssetResourceLoader only
+                // holds a weak reference).
+                if (storeDelegate) {
+                    if (isPrimary) {
+                        _resourceLoaderDelegate = delegate;
+                    } else {
+                        _resourceLoaderDelegate2 = delegate;
+                    }
+                }
+
+                item = [[IndexedPlayerItem alloc] initWithAsset:asset];
+            }
+        }
+
+        if (!useResourceLoader) {
+            // Fallback: direct URL loading (for non-HTTP or if interception failed).
+            // Still try to preserve percent-encoding via NSURLComponents.
+            NSURL *url = nil;
+            NSURLComponents *components = [NSURLComponents componentsWithString:uri];
+            if (components) {
+                NSRange queryRange = [uri rangeOfString:@"?"];
+                if (queryRange.location != NSNotFound) {
+                    NSString *rawQuery = [uri substringFromIndex:queryRange.location + 1];
+                    NSRange fragmentRange = [rawQuery rangeOfString:@"#"];
+                    if (fragmentRange.location != NSNotFound) {
+                        rawQuery = [rawQuery substringToIndex:fragmentRange.location];
+                    }
+                    components.percentEncodedQuery = rawQuery;
+                }
+                url = components.URL;
+            }
+            if (!url) {
+                url = [NSURL URLWithString:uri];
+            }
+            if (!url) {
+                NSLog(@"just_audio: ERROR: Failed to create NSURL from URI: %@", uri);
+                url = [NSURL URLWithString:@"about:blank"];
+            }
+            AVURLAsset *asset = [AVURLAsset URLAssetWithURL:url options:assetOptions];
+            item = [[IndexedPlayerItem alloc] initWithAsset:asset];
+        }
     }
     if (@available(macOS 10.13, iOS 11.0, *)) {
         // This does the best at reducing distortion on voice with speeds below 1.0
@@ -165,11 +234,15 @@
     IndexedPlayerItem *temp = _playerItem;
     _playerItem = _playerItem2;
     _playerItem2 = temp;
+    // Also swap the resource loader delegates
+    ResourceLoaderDelegate *tempDelegate = _resourceLoaderDelegate;
+    _resourceLoaderDelegate = _resourceLoaderDelegate2;
+    _resourceLoaderDelegate2 = tempDelegate;
 }
 
 - (void)preparePlayerItem2 {
     if (!_playerItem2) {
-        _playerItem2 = [self createPlayerItem:_uri];
+        _playerItem2 = [self createPlayerItem:_uri storeDelegate:YES isPrimary:NO];
         _playerItem2.audioSource = _playerItem.audioSource;
     }
 }

--- a/just_audio/darwin/just_audio/Sources/just_audio/include/just_audio/ResourceLoaderDelegate.h
+++ b/just_audio/darwin/just_audio/Sources/just_audio/include/just_audio/ResourceLoaderDelegate.h
@@ -1,0 +1,34 @@
+#import <AVFoundation/AVFoundation.h>
+
+/// A custom AVAssetResourceLoaderDelegate that intercepts HTTP(S) requests
+/// made by AVFoundation and handles them through NSURLSession.
+///
+/// This is necessary because iOS 17+ changed the URL parser to RFC 3986,
+/// which normalizes percent-encoded characters in query strings (e.g.
+/// %2B → +, %3D → =). For signed/verified URLs, this normalization
+/// breaks server-side signature validation.
+///
+/// By using a custom URL scheme, AVFoundation delegates all network
+/// loading to us, allowing us to make HTTP requests with the exact
+/// original URL preserving percent-encoding.
+@interface ResourceLoaderDelegate : NSObject <AVAssetResourceLoaderDelegate>
+
+/// The original HTTP(S) URL with preserved percent-encoding.
+@property (readonly, nonatomic) NSString *originalURLString;
+
+/// Custom URL scheme prefix used to intercept requests.
++ (NSString *)customSchemePrefix;
+
+/// Converts an HTTP(S) URL to a custom-scheme URL for interception.
+/// e.g. https://example.com → just-audio-https://example.com
++ (NSString *)interceptedURLString:(NSString *)urlString;
+
+/// Returns YES if the given URL string uses the custom interception scheme.
++ (BOOL)isInterceptedURLString:(NSString *)urlString;
+
+- (instancetype)initWithOriginalURLString:(NSString *)originalURLString headers:(NSDictionary *)headers;
+
+/// Cancels any pending requests and cleans up resources.
+- (void)invalidate;
+
+@end

--- a/just_audio/darwin/just_audio/Sources/just_audio/include/just_audio/UriAudioSource.h
+++ b/just_audio/darwin/just_audio/Sources/just_audio/include/just_audio/UriAudioSource.h
@@ -1,5 +1,6 @@
 #import "IndexedAudioSource.h"
 #import "LoadControl.h"
+#import "ResourceLoaderDelegate.h"
 #import <AVFoundation/AVFoundation.h>
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>


### PR DESCRIPTION
1) Why this was changed
On iOS 17, AVFoundation/NSURL handling became stricter (RFC 3986 behavior).
For signed URLs, even small normalization in query encoding can invalidate signatures (like verify= token), leading to generic AVPlayer load failures (-11800).

So the fix avoids AVFoundation doing the network fetch directly for HTTP(S) URLs.

2) What ResourceLoaderDelegate introduces
The new ResourceLoaderDelegate class is a custom AVAssetResourceLoaderDelegate that makes AVPlayer ask your code for media bytes instead of Apple’s internal URL loader.

From your header:

originalURLString
Stores the exact original HTTP(S) URL string (with original percent-encoding preserved).

+customSchemePrefix
Returns a prefix like just-audio-.

+interceptedURLString:
Converts normal URLs to custom-scheme URLs:

https://... → just-audio-https://...
http://... → just-audio-http://...
+isInterceptedURLString:
Detects whether a URL is already converted.

-initWithOriginalURLString:headers:
Creates the delegate with the exact URL and optional request headers.

-invalidate
Cancels active network work and clears pending loading requests.

3) How playback now works
Before
AVURLAsset was created with the real https://... URL.
AVFoundation handled network loading internally, and iOS 17 could normalize URL/query representation.

After
URL is converted to custom scheme (just-audio-https://...).
AVURLAsset is created with that intercepted URL.
AVFoundation cannot fetch that scheme itself, so it calls AVAssetResourceLoaderDelegate.
ResourceLoaderDelegate receives each loading request.
Delegate maps intercepted URL back to the stored original URL string.
Delegate performs HTTP via NSURLSession using that original URL + headers.
Delegate supplies:
content info (MIME/UTI, length, byte-range support)
requested byte ranges (for seek/stream)
AVPlayer plays normally from returned data.
This gives full control over request construction and avoids unintended URL mutation in AVFoundation’s internal loader path.

4) Supporting changes around it
UriAudioSource
Uses intercepted URL for HTTP(S) assets.
Creates and attaches ResourceLoaderDelegate.
Keeps a strong reference to delegate(s), because AVAssetResourceLoader keeps delegates weakly.
(Without this, delegate could deallocate mid-playback.)
AudioPlayer error reporting
Error packaging was expanded to include underlying NSError chain and more details.
Goal: replace vague -11800 with actionable root causes (HTTP status, transport/TLS, decode failure, etc.).
Build config (podspec / Package.swift)
Updated so required Apple frameworks/linking for this loader path are available.
5) Why this is the right class of fix
It doesn’t “fight” URL parsing heuristics with repeated re-encoding.
Instead, it moves loading to a controlled path where the plugin explicitly issues the request and returns bytes, which is robust across iOS parser behavior changes.

6) What to expect behavior-wise
Signed URLs should now be requested exactly as intended.
Seeking should still work (byte-range handling).
If failures persist, logs should now expose specific underlying causes (e.g., 403/404, ATS, TLS, unsupported codec), not only -11800.