### PR TITLE
Fix seek playlist index.

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -1750,8 +1750,10 @@ class AudioPlayer {
       subscribeToEvents(platform);
 
       try {
-        final initialSeekValues = pluginLoadRequest?.initialSeekValues ??
-            (index: currentIndex, position: position);
+        final initialSeekValues = (
+          index: pluginLoadRequest?.initialSeekValues.index ?? currentIndex,
+          position: pluginLoadRequest?.initialSeekValues.position ?? position,
+        );
         final duration = await _load(
           platform,
           _playlist,


### PR DESCRIPTION
During seek method the pluginLoadRequest values are reset, so after setPlatformActive previous set index are disappear.
It fixed #1575