### PR TITLE
fix(android): null-guard equalizer methods to prevent NPE during session swaps

### DIFF
--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
@@ -820,7 +820,9 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
     }
 
     private void audioEffectSetEnabled(String type, boolean enabled) {
-        audioEffectsMap.get(type).setEnabled(enabled);
+        AudioEffect effect = audioEffectsMap.get(type);
+        if (effect == null) return;
+        effect.setEnabled(enabled);
     }
 
     private void loudnessEnhancerSetTargetGain(double targetGain) {
@@ -830,6 +832,7 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
 
     private Map<String, Object> equalizerAudioEffectGetParameters() {
         Equalizer equalizer = (Equalizer)audioEffectsMap.get("AndroidEqualizer");
+        if (equalizer == null) return null;
         ArrayList<Object> rawBands = new ArrayList<>();
         for (short i = 0; i < equalizer.getNumberOfBands(); i++) {
             rawBands.add(mapOf(
@@ -850,7 +853,9 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
     }
 
     private void equalizerBandSetGain(int bandIndex, double gain) {
-        ((Equalizer)audioEffectsMap.get("AndroidEqualizer")).setBandLevel((short)bandIndex, (short)(Math.round(gain * 100.0))); // target gain needs to be provided in milliBel, the user provides the value in deciBel
+        Equalizer equalizer = (Equalizer)audioEffectsMap.get("AndroidEqualizer");
+        if (equalizer == null) return;
+        equalizer.setBandLevel((short)bandIndex, (short)(Math.round(gain * 100.0))); // target gain needs to be provided in milliBel, the user provides the value in deciBel
     }
 
     /// Creates an event based on the current state.


### PR DESCRIPTION
**audioEffectSetEnabled**, **equalizerAudioEffectGetParameters**, and **equalizerBandSetGain** can be called by the plugin's internal onAudioSessionIdChanged callback while the native AudioEffect / Equalizer handle is transiently null — for example during a rapid setAudioSources rebuild. This results in a **NullPointerException** that surfaces as a PlatformException in Dart.

This PR adds an early-return null check at the top of each of the three methods. If the native handle is null the call is silently skipped; the effect state is expected to be restored once the new audio session is fully established.