### PR TITLE
fix: only proxy http(s) URIs, not content:// and other schemes

### DIFF
--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -2745,7 +2745,7 @@ abstract class UriAudioSource extends IndexedAudioSource {
     await super._onLoad();
     if (uri.scheme == 'asset') {
       _overrideUri = await _loadAsset(uri.pathSegments.join('/'));
-    } else if (uri.scheme != 'file' &&
+    } else if ((uri.scheme == 'http' || uri.scheme == 'https') &&
         !kIsWeb &&
         _player!._useProxyForRequestHeaders &&
         (headers != null || _player!._userAgent != null)) {

--- a/just_audio/test/just_audio_test.dart
+++ b/just_audio/test/just_audio_test.dart
@@ -481,6 +481,18 @@ void runTests() {
     await player.dispose();
   });
 
+  test('content URI skips proxy', () async {
+    final player = AudioPlayer(userAgent: 'TestAgent');
+    final contentUri = 'content://com.example.provider/audio/test.mp3';
+    await player.setUrl(contentUri);
+    // The platform-side URL should be the original content:// URI,
+    // not rewritten to a localhost proxy URL.
+    final platformUri = player.icyMetadata!.info!.url!;
+    expect(platformUri, equals(contentUri));
+    expect(platformUri, isNot(startsWith('http://127.0.0.1')));
+    await player.dispose();
+  });
+
   test('proxy0.9', () async {
     final server = MockWebServer();
     await server.start();


### PR DESCRIPTION
Fixes #1591.

## Summary

`UriAudioSource._onLoad` proxied every URI scheme except `file://`. This wrongly routed Android SAF `content://` URIs (which carry SAF permission grants) through the internal HTTP proxy, breaking playback of user-selected local media whenever a custom `userAgent` or `headers` were configured.

## Change

Switches the proxy gate from a broad blacklist to a tight allowlist — only `http`/`https` is proxied; `content://`, `asset://` and other schemes pass through to the platform layer untouched.

```diff
-    } else if (uri.scheme != 'file' &&
+    } else if ((uri.scheme == 'http' || uri.scheme == 'https') &&
```

## Test

Adds a regression test asserting a `content://` URI reaches the platform layer unchanged.
