### PR TITLE
Fix web replaying the first loaded source on every subsequent load

### DIFF
--- a/just_audio_web/CHANGELOG.md
+++ b/just_audio_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.17
+
+* Fix stale audio source cache in load() replaying the first loaded source on subsequent loads (#1513, #1454) (@AugustLigh).
+
 ## 0.4.16
 
 * Fix play interrupted by load.

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -258,6 +258,15 @@ class Html5AudioPlayer extends JustAudioPlayer {
   @override
   Future<LoadResponse> load(LoadRequest request) async {
     _currentAudioSourcePlayer?.pause();
+    // Since just_audio 0.10, every load() transmits the player's internal
+    // playlist, whose ID stays the same for the player's lifetime. Without
+    // invalidation, the cache below would keep returning the source tree
+    // built on the first load, replaying the original audio no matter what
+    // was loaded afterwards (#1513, #1454). A load starts a new lifecycle
+    // for the whole tree: reset the cache and let getAudioSource rebuild it
+    // from the incoming message (it re-registers every node, so subsequent
+    // playlist operations that look up players by ID keep working).
+    _audioSourcePlayers.clear();
     _audioSourcePlayer = getAudioSource(request.audioSourceMessage);
     _index = request.initialIndex ?? 0;
     final duration = await _currentAudioSourcePlayer!

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: just_audio_web
 description: Web platform implementation of just_audio. This implementation is endorsed and therefore doesn't require a direct dependency.
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_web
-version: 0.4.16
+version: 0.4.17
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes #1513. Root cause matches the analysis in #1454.

**Problem**

On web, since just_audio 0.10.x, every `setUrl`/`setAudioSource`/`setAudioSources` after the first keeps playing the first loaded audio until the page is reloaded. Mobile is unaffected. Downgrading to 0.9.46 avoids it.

**Cause**

Since 0.10, `AudioPlayer` keeps one internal playlist whose message ID never changes for the player's lifetime, and sends it with every `LoadRequest`. `Html5AudioPlayer.getAudioSource` caches source players by message ID, and `load()` never invalidates that cache — so from the second load on, the cached tree built on the first load is returned and the original audio replays. In 0.9.x the root source of each load was user-created with a fresh ID, which is why this never surfaced before (see the commit referenced in #1454 that replaced `_playlist.clear`/`addAll` with `_playlist._init`).

**Fix**

Clear `_audioSourcePlayers` at the start of `load()`. A load starts a new lifecycle for the whole source tree; `getAudioSource` immediately re-registers every node from the incoming message, so subsequent `concatenatingInsertAll`/`RemoveRange`/`Move` lookups by ID keep working. Unlike #1518 (which disables the cache check inside `getAudioSource` itself), this keeps cache semantics intact between playlist operations and only resets per load.

**Verification**

Reproduced with two players mirroring a real app (a voice-message player using `setUrl` and a playlist player using `setAudioSource` with `ConcatenatingAudioSource`), with tone files of distinct durations (3s/6s/9s) served over HTTP:

- Before: after the first load, `player.duration` stayed at the first file's duration on every subsequent load, and DevTools/server logs showed no network requests for the new URLs.
- After: every scenario loads and plays the requested source (durations and network requests match) — switching mid-play, after completion, alternating between two players, and repeated `setAudioSource` with different playlists.

Per CONTRIBUTING.md: targeted at `minor`, version bumped to 0.4.17, CHANGELOG entry added, `flutter analyze` is clean (just_audio_web has no test suite).
