### PR TITLE
Add optional DRM config for Dash/Hls on Android and iOS

### DIFF
--- a/just_audio/CHANGELOG.md
+++ b/just_audio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.7
+
+* Add optional DRM support for DashAudioSource and HlsAudioSource (Widevine on Android, FairPlay on iOS/macOS) (@Francisny03).
+
 ## 0.10.6
 
 * Support AGP 9.

--- a/just_audio/README.md
+++ b/just_audio/README.md
@@ -114,6 +114,24 @@ Note: By default, headers are implemented via a local HTTP proxy which on Androi
 
 Alternatively, settings `useProxyForRequestHeaders: false` will use the platform's native headers implementation without a proxy. Although note that iOS doesn't offer an official native API for setting headers, and so this will use the undocumented `AVURLAssetHTTPHeaderFieldsKey` API (or in the case of the user-agent header on iOS 16 and above, the official `AVURLAssetHTTPUserAgentKey` API).
 
+### Working with DRM
+
+Optional DRM configuration can be supplied on [DashAudioSource] or [HlsAudioSource]. License URLs and headers are provided by your app at runtime; just_audio does not embed license tokens.
+
+```dart
+final source = HlsAudioSource(
+  Uri.parse('https://example.com/stream.m3u8'),
+  drm: DrmConfiguration(
+    licenseUrl: 'https://license.example.com/fairplay',
+    licenseHeaders: {'Authorization': 'Bearer <token>'},
+    fairplayCertUrl: 'https://license.example.com/fairplay/cert',
+  ),
+);
+await player.setAudioSource(source);
+```
+
+On Android, Widevine is used via ExoPlayer. On iOS/macOS, FairPlay Streaming is used via `AVContentKeySession`. `fairplayCertUrl` is required for FairPlay and ignored on Android. You can also use `AudioSource.drm(...)` to pick DASH vs HLS from the URI path.
+
 ### Working with caches
 
 ```dart

--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
@@ -640,19 +640,30 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
                             .setUri(Uri.parse((String)map.get("uri")))
                             .setTag(id)
                             .build());
-        case "dash":
+        case "dash": {
+            MediaItem.Builder dashItemBuilder = new MediaItem.Builder()
+                    .setUri(Uri.parse((String)map.get("uri")))
+                    .setMimeType(MimeTypes.APPLICATION_MPD)
+                    .setTag(id);
+            MediaItem.DrmConfiguration dashDrmConfiguration = buildDrmConfiguration(mapGet(map, "drm"));
+            if (dashDrmConfiguration != null) {
+                dashItemBuilder.setDrmConfiguration(dashDrmConfiguration);
+            }
             return new DashMediaSource.Factory(buildDataSourceFactory(mapGet(map, "headers")))
-                    .createMediaSource(new MediaItem.Builder()
-                            .setUri(Uri.parse((String)map.get("uri")))
-                            .setMimeType(MimeTypes.APPLICATION_MPD)
-                            .setTag(id)
-                            .build());
-        case "hls":
+                    .createMediaSource(dashItemBuilder.build());
+        }
+        case "hls": {
+            MediaItem.Builder hlsItemBuilder = new MediaItem.Builder()
+                    .setUri(Uri.parse((String)map.get("uri")))
+                    .setMimeType(MimeTypes.APPLICATION_M3U8)
+                    .setTag(id);
+            MediaItem.DrmConfiguration hlsDrmConfiguration = buildDrmConfiguration(mapGet(map, "drm"));
+            if (hlsDrmConfiguration != null) {
+                hlsItemBuilder.setDrmConfiguration(hlsDrmConfiguration);
+            }
             return new HlsMediaSource.Factory(buildDataSourceFactory(mapGet(map, "headers")))
-                    .createMediaSource(new MediaItem.Builder()
-                            .setUri(Uri.parse((String)map.get("uri")))
-                            .setMimeType(MimeTypes.APPLICATION_M3U8)
-                            .build());
+                    .createMediaSource(hlsItemBuilder.build());
+        }
         case "silence":
             return new SilenceMediaSource.Factory()
                     .setDurationUs(getLong(map.get("duration")))
@@ -726,6 +737,29 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
             it.remove();
         }
         audioEffectsMap.clear();
+    }
+
+    // Builds a Widevine DRM configuration for a "dash"/"hls" audio source
+    // when the Dart-side map included a "drm" entry, e.g.:
+    // {
+    //   "licenseUrl": "https://license.example.com/widevine",
+    //   "licenseHeaders": {"Authorization": "..."},
+    //   "fairplayCertUrl": null // unused on Android
+    // }
+    private MediaItem.DrmConfiguration buildDrmConfiguration(Map<?, ?> drm) {
+        if (drm == null) return null;
+        Object licenseUrlObj = drm.get("licenseUrl");
+        if (!(licenseUrlObj instanceof String) || ((String)licenseUrlObj).isEmpty()) return null;
+        String licenseUrl = (String)licenseUrlObj;
+        Map<String, String> licenseHeaders = castToStringMap((Map<?, ?>)drm.get("licenseHeaders"));
+        MediaItem.DrmConfiguration.Builder drmBuilder =
+                new MediaItem.DrmConfiguration.Builder(C.WIDEVINE_UUID)
+                        .setLicenseUri(licenseUrl)
+                        .setMultiSession(false);
+        if (licenseHeaders != null && licenseHeaders.size() > 0) {
+            drmBuilder.setLicenseRequestHeaders(licenseHeaders);
+        }
+        return drmBuilder.build();
     }
 
     private DataSource.Factory buildDataSourceFactory(Map<?, ?> headers) {

--- a/just_audio/darwin/just_audio/Sources/just_audio/AudioPlayer.m
+++ b/just_audio/darwin/just_audio/Sources/just_audio/AudioPlayer.m
@@ -473,9 +473,9 @@
     if ([@"progressive" isEqualToString:type]) {
         return [[UriAudioSource alloc] initWithId:data[@"id"] uri:data[@"uri"] loadControl:_loadControl headers:data[@"headers"] options:data[@"options"]];
     } else if ([@"dash" isEqualToString:type]) {
-        return [[UriAudioSource alloc] initWithId:data[@"id"] uri:data[@"uri"] loadControl:_loadControl headers:data[@"headers"] options:data[@"options"]];
+        return [[UriAudioSource alloc] initWithId:data[@"id"] uri:data[@"uri"] loadControl:_loadControl headers:data[@"headers"] options:data[@"options"] drm:data[@"drm"]];
     } else if ([@"hls" isEqualToString:type]) {
-        return [[UriAudioSource alloc] initWithId:data[@"id"] uri:data[@"uri"] loadControl:_loadControl headers:data[@"headers"] options:data[@"options"]];
+        return [[UriAudioSource alloc] initWithId:data[@"id"] uri:data[@"uri"] loadControl:_loadControl headers:data[@"headers"] options:data[@"options"] drm:data[@"drm"]];
     } else if ([@"concatenating" isEqualToString:type]) {
         return [[ConcatenatingAudioSource alloc] initWithId:data[@"id"]
                                                audioSources:[self decodeAudioSources:data[@"children"]]

--- a/just_audio/darwin/just_audio/Sources/just_audio/UriAudioSource.m
+++ b/just_audio/darwin/just_audio/Sources/just_audio/UriAudioSource.m
@@ -4,23 +4,264 @@
 #import "./include/just_audio/LoadControl.h"
 #import <AVFoundation/AVFoundation.h>
 
+/// FairPlay Streaming license exchange via AVContentKeySession.
+@interface _JustAudioFairPlayDelegate : NSObject <AVContentKeySessionDelegate>
+@property (nonatomic, copy) NSString *licenseUrl;
+@property (nonatomic, copy) NSString *fairplayCertUrl;
+@property (nonatomic, copy) NSDictionary<NSString *, NSString *> *licenseHeaders;
+@end
+
+@implementation _JustAudioFairPlayDelegate
+
+/// Content ID for SPC: strip `skd://` (Apple FPS convention).
+/// Using the full `skd://…` absoluteString breaks license exchange.
+- (nullable NSData *)_contentIdDataFromKeyRequest:(AVContentKeyRequest *)keyRequest {
+    id identifier = keyRequest.identifier;
+    NSString *raw = nil;
+    if ([identifier isKindOfClass:[NSURL class]]) {
+        NSURL *url = (NSURL *)identifier;
+        // Prefer host when URI is skd://<contentId>
+        if (url.host.length > 0) {
+            raw = url.host;
+        } else {
+            raw = url.absoluteString;
+        }
+    } else if ([identifier isKindOfClass:[NSString class]]) {
+        raw = (NSString *)identifier;
+    } else if ([identifier isKindOfClass:[NSData class]]) {
+        return (NSData *)identifier;
+    }
+    if (raw.length == 0) return nil;
+
+    NSString *stripped = raw;
+    if ([stripped.lowercaseString hasPrefix:@"skd://"]) {
+        stripped = [stripped substringFromIndex:6];
+    }
+    NSString *decoded = [stripped stringByRemovingPercentEncoding] ?: stripped;
+    if (decoded.length == 0) return nil;
+    return [decoded dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+- (void)_postLicenseWithSpc:(NSData *)spcData
+                 keyRequest:(AVContentKeyRequest *)keyRequest API_AVAILABLE(ios(10.3), macos(10.12.4)) {
+    NSString *spcB64 = [spcData base64EncodedStringWithOptions:0];
+    // Many FairPlay license servers expect application/x-www-form-urlencoded
+    // with an encodeURIComponent-style `spc=` body.
+    NSCharacterSet *allowed = [NSCharacterSet
+        characterSetWithCharactersInString:
+            @"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"];
+    NSString *encoded = [spcB64 stringByAddingPercentEncodingWithAllowedCharacters:allowed]
+        ?: spcB64;
+    NSString *bodyString = [NSString stringWithFormat:@"spc=%@", encoded];
+    NSData *body = [bodyString dataUsingEncoding:NSUTF8StringEncoding];
+
+    NSURL *licenseURL = [NSURL URLWithString:self.licenseUrl];
+    if (!licenseURL) {
+        [keyRequest processContentKeyResponseError:
+            [NSError errorWithDomain:@"just_audio.drm" code:5
+                            userInfo:@{NSLocalizedDescriptionKey: @"Invalid FairPlay license URL"}]];
+        return;
+    }
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:licenseURL];
+    req.HTTPMethod = @"POST";
+    [req setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+    for (NSString *key in self.licenseHeaders) {
+        id value = self.licenseHeaders[key];
+        if ([value isKindOfClass:[NSString class]]) {
+            [req setValue:(NSString *)value forHTTPHeaderField:key];
+        }
+    }
+    req.HTTPBody = body;
+
+    [[[NSURLSession sharedSession] dataTaskWithRequest:req
+                                     completionHandler:^(NSData *ckcData, NSURLResponse *licResponse, NSError *licError) {
+        NSHTTPURLResponse *http = (NSHTTPURLResponse *)licResponse;
+        NSInteger status = [http isKindOfClass:[NSHTTPURLResponse class]] ? http.statusCode : 0;
+        if (licError || ckcData.length == 0 || status < 200 || status >= 300) {
+            NSString *msg = [NSString stringWithFormat:
+                @"FairPlay license failed (HTTP %ld, %lu bytes)",
+                (long)status, (unsigned long)ckcData.length];
+            NSLog(@"[just_audio DRM] %@", msg);
+            [keyRequest processContentKeyResponseError:
+                licError ?: [NSError errorWithDomain:@"just_audio.drm" code:4
+                                          userInfo:@{NSLocalizedDescriptionKey: msg}]];
+            return;
+        }
+        // Some license servers return HTTP 200 + JSON error — reject before CKC parse.
+        NSString *asText = [[NSString alloc] initWithData:ckcData encoding:NSUTF8StringEncoding];
+        if (asText != nil) {
+            NSString *trimmed = [asText stringByTrimmingCharactersInSet:
+                [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+            if ([trimmed hasPrefix:@"{"]) {
+                NSLog(@"[just_audio DRM] license JSON error: %@", trimmed);
+                [keyRequest processContentKeyResponseError:
+                    [NSError errorWithDomain:@"just_audio.drm" code:8
+                                    userInfo:@{NSLocalizedDescriptionKey: trimmed}]];
+                return;
+            }
+        }
+        NSData *rawCkc = [self _decodeIfBase64:ckcData] ?: ckcData;
+        if (rawCkc.length == 0) {
+            [keyRequest processContentKeyResponseError:
+                [NSError errorWithDomain:@"just_audio.drm" code:9
+                                userInfo:@{NSLocalizedDescriptionKey: @"Empty FairPlay CKC"}]];
+            return;
+        }
+        NSLog(@"[just_audio DRM] CKC ok (%lu bytes)", (unsigned long)rawCkc.length);
+        AVContentKeyResponse *keyResponse =
+            [AVContentKeyResponse contentKeyResponseWithFairPlayStreamingKeyResponseData:rawCkc];
+        [keyRequest processContentKeyResponse:keyResponse];
+    }] resume];
+}
+
+- (void)contentKeySession:(AVContentKeySession *)session
+    didProvideContentKeyRequest:(AVContentKeyRequest *)keyRequest API_AVAILABLE(ios(10.3), macos(10.12.4)) {
+    NSURL *certURL = [NSURL URLWithString:_fairplayCertUrl];
+    if (!certURL) {
+        [keyRequest processContentKeyResponseError:
+            [NSError errorWithDomain:@"just_audio.drm" code:1
+                            userInfo:@{NSLocalizedDescriptionKey: @"Invalid FairPlay cert URL"}]];
+        return;
+    }
+
+    NSData *contentId = [self _contentIdDataFromKeyRequest:keyRequest];
+    if (contentId.length == 0) {
+        NSLog(@"[just_audio DRM] missing FairPlay content id from keyRequest.identifier=%@",
+              keyRequest.identifier);
+        [keyRequest processContentKeyResponseError:
+            [NSError errorWithDomain:@"just_audio.drm" code:6
+                            userInfo:@{NSLocalizedDescriptionKey: @"Missing FairPlay content id"}]];
+        return;
+    }
+    NSLog(@"[just_audio DRM] contentId=%@",
+          [[NSString alloc] initWithData:contentId encoding:NSUTF8StringEncoding]);
+
+    [[[NSURLSession sharedSession] dataTaskWithURL:certURL
+                                 completionHandler:^(NSData *certData, NSURLResponse *response, NSError *error) {
+        if (error || certData.length == 0) {
+            [keyRequest processContentKeyResponseError:
+                error ?: [NSError errorWithDomain:@"just_audio.drm" code:2
+                                          userInfo:@{NSLocalizedDescriptionKey: @"FairPlay cert fetch failed"}]];
+            return;
+        }
+
+        // Certificate endpoint may return raw DER or base64 text.
+        // Apple requires raw certificate bytes as appIdentifier.
+        NSData *rawCert = [self _fpsCertificateBytes:certData];
+        if (rawCert.length == 0) {
+            NSString *preview = [[NSString alloc] initWithData:certData encoding:NSUTF8StringEncoding] ?: @"";
+            if (preview.length > 240) preview = [preview substringToIndex:240];
+            // Some servers return HTTP 200 + JSON when the cert is unavailable.
+            NSString *msg = [preview hasPrefix:@"{"]
+                ? [NSString stringWithFormat:
+                    @"FairPlay cert unavailable: %@", preview]
+                : [NSString stringWithFormat:
+                    @"Invalid FairPlay certificate payload: %@", preview];
+            NSLog(@"[just_audio DRM] %@", msg);
+            [keyRequest processContentKeyResponseError:
+                [NSError errorWithDomain:@"just_audio.drm" code:7
+                                userInfo:@{NSLocalizedDescriptionKey: msg}]];
+            return;
+        }
+        NSLog(@"[just_audio DRM] FPS cert decoded (%lu bytes)", (unsigned long)rawCert.length);
+
+        [keyRequest makeStreamingContentKeyRequestDataForApp:rawCert
+                                           contentIdentifier:contentId
+                                                     options:nil
+                                           completionHandler:^(NSData * _Nullable spcData, NSError * _Nullable spcError) {
+            if (spcError || spcData.length == 0) {
+                NSLog(@"[just_audio DRM] SPC generation failed: %@", spcError);
+                [keyRequest processContentKeyResponseError:
+                    spcError ?: [NSError errorWithDomain:@"just_audio.drm" code:3
+                                              userInfo:@{NSLocalizedDescriptionKey: @"SPC generation failed"}]];
+                return;
+            }
+            [self _postLicenseWithSpc:spcData keyRequest:keyRequest];
+        }];
+    }] resume];
+}
+
+- (void)contentKeySession:(AVContentKeySession *)session
+    didProvidePersistableContentKeyRequest:(AVPersistableContentKeyRequest *)keyRequest API_AVAILABLE(ios(10.3), macos(10.15)) {
+    [self contentKeySession:session didProvideContentKeyRequest:keyRequest];
+}
+
+/// FairPlay cert endpoint may return base64 text (or JSON error with HTTP 200).
+- (nullable NSData *)_fpsCertificateBytes:(NSData *)body {
+    if (body.length == 0) return nil;
+    // Already looks like DER (SEQUENCE tag 0x30) — use as-is.
+    const uint8_t *bytes = body.bytes;
+    if (bytes[0] == 0x30) return body;
+
+    NSString *text = [[[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding]
+        stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (text.length == 0) return nil;
+    if ([text hasPrefix:@"{"]) {
+        // JSON error body (still HTTP 200).
+        return nil;
+    }
+    NSData *decoded = [[NSData alloc] initWithBase64EncodedString:text
+                                                          options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    return decoded.length > 0 ? decoded : nil;
+}
+
+- (nullable NSData *)_decodeIfBase64:(NSData *)data {
+    if (data.length == 0) return nil;
+    // License failures may also return HTTP 200 + JSON — don't treat as CKC.
+    NSString *asText = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    if (asText != nil) {
+        NSString *trimmed = [asText stringByTrimmingCharactersInSet:
+            [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if ([trimmed hasPrefix:@"{"]) {
+            NSLog(@"[just_audio DRM] license JSON error: %@", trimmed);
+            return nil;
+        }
+    }
+    const uint8_t *bytes = data.bytes;
+    for (NSUInteger i = 0; i < data.length; i++) {
+        uint8_t b = bytes[i];
+        BOOL ok = (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') ||
+                  (b >= '0' && b <= '9') || b == '+' || b == '/' || b == '=' ||
+                  b == '\n' || b == '\r';
+        if (!ok) return nil;
+    }
+    NSString *text = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]
+        stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (text.length == 0) return nil;
+    return [[NSData alloc] initWithBase64EncodedString:text options:NSDataBase64DecodingIgnoreUnknownCharacters];
+}
+
+@end
+
 @implementation UriAudioSource {
     NSString *_uri;
     IndexedPlayerItem *_playerItem;
     IndexedPlayerItem *_playerItem2;
-    /* CMTime _duration; */
     LoadControl *_loadControl;
     NSMutableDictionary *_headers;
     NSDictionary *_options;
+    NSDictionary *_drm;
+    AVContentKeySession *_contentKeySession;
+    _JustAudioFairPlayDelegate *_fairPlayDelegate;
 }
 
 - (instancetype)initWithId:(NSString *)sid uri:(NSString *)uri loadControl:(LoadControl *)loadControl headers:(NSDictionary *)headers options:(NSDictionary *)options {
+    return [self initWithId:sid uri:uri loadControl:loadControl headers:headers options:options drm:nil];
+}
+
+- (instancetype)initWithId:(NSString *)sid
+                       uri:(NSString *)uri
+               loadControl:(LoadControl *)loadControl
+                   headers:(NSDictionary *)headers
+                   options:(NSDictionary *)options
+                       drm:(NSDictionary *)drm {
     self = [super initWithId:sid];
     NSAssert(self, @"super init cannot be nil");
     _uri = uri;
     _loadControl = loadControl;
     _headers = headers != (id)[NSNull null] ? [headers mutableCopy] : nil;
-    _options = options;
+    _options = options != (id)[NSNull null] ? options : nil;
+    _drm = drm != (id)[NSNull null] ? drm : nil;
     _playerItem = [self createPlayerItem:uri];
     _playerItem2 = nil;
     return self;
@@ -30,17 +271,56 @@
     return _uri;
 }
 
+- (void)_attachFairPlayIfNeeded:(AVURLAsset *)asset {
+    if (!_drm) return;
+    NSString *licenseUrl = _drm[@"licenseUrl"];
+    NSString *certUrl = _drm[@"fairplayCertUrl"];
+    if (![licenseUrl isKindOfClass:[NSString class]] || licenseUrl.length == 0) {
+        NSLog(@"[just_audio DRM] missing licenseUrl — FairPlay not attached");
+        return;
+    }
+    if (![certUrl isKindOfClass:[NSString class]] || certUrl.length == 0) {
+        // Without a cert, AVPlayer fails encrypted HLS with opaque -11800.
+        NSLog(@"[just_audio DRM] missing fairplayCertUrl — FairPlay not attached");
+        return;
+    }
+    if (@available(iOS 10.3, macOS 10.12.4, *)) {
+        _fairPlayDelegate = [[_JustAudioFairPlayDelegate alloc] init];
+        _fairPlayDelegate.licenseUrl = licenseUrl;
+        _fairPlayDelegate.fairplayCertUrl = certUrl;
+        NSDictionary *headers = _drm[@"licenseHeaders"];
+        if ([headers isKindOfClass:[NSDictionary class]]) {
+            NSMutableDictionary<NSString *, NSString *> *stringHeaders =
+                [NSMutableDictionary dictionary];
+            [headers enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+                if ([key isKindOfClass:[NSString class]] &&
+                    [obj isKindOfClass:[NSString class]]) {
+                    stringHeaders[(NSString *)key] = (NSString *)obj;
+                }
+            }];
+            _fairPlayDelegate.licenseHeaders = stringHeaders;
+        } else {
+            _fairPlayDelegate.licenseHeaders = @{};
+        }
+        _contentKeySession =
+            [AVContentKeySession contentKeySessionWithKeySystem:AVContentKeySystemFairPlayStreaming];
+        [_contentKeySession setDelegate:_fairPlayDelegate queue:dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0)];
+        [_contentKeySession addContentKeyRecipient:asset];
+        NSLog(@"[just_audio DRM] FairPlay ContentKeySession attached for %@", asset.URL);
+    }
+}
+
 - (IndexedPlayerItem *)createPlayerItem:(NSString *)uri {
     IndexedPlayerItem *item;
     NSMutableDictionary *assetOptions = [[NSMutableDictionary alloc] init];
-    
-    if (_options != (id)[NSNull null]) {
+
+    if (_options != (id)[NSNull null] && _options != nil) {
         NSDictionary *darwinOptions = _options[@"darwinAssetOptions"];
-        if (darwinOptions != (id)[NSNull null]) {
+        if (darwinOptions != (id)[NSNull null] && darwinOptions != nil) {
             assetOptions[AVURLAssetPreferPreciseDurationAndTimingKey] = darwinOptions[@"preferPreciseDurationAndTiming"];
         }
     }
-    
+
     if ([uri hasPrefix:@"file://"]) {
         NSURL *fileURL = [NSURL fileURLWithPath:[[uri stringByRemovingPercentEncoding] substringFromIndex:7]];
         AVURLAsset *asset = [AVURLAsset URLAssetWithURL:fileURL options:assetOptions];
@@ -68,8 +348,9 @@
                 assetOptions[@"AVURLAssetHTTPHeaderFieldsKey"] = _headers;
             }
         }
-        
+
         AVURLAsset *asset = [AVURLAsset URLAssetWithURL:[NSURL URLWithString:uri] options:assetOptions];
+        [self _attachFairPlayIfNeeded:asset];
         item = [[IndexedPlayerItem alloc] initWithAsset:asset];
     }
     if (@available(macOS 10.13, iOS 11.0, *)) {
@@ -197,7 +478,7 @@
     } else {
         return _playerItem.currentTime;
     }
-    
+
 }
 
 - (CMTime)bufferedPosition {

--- a/just_audio/darwin/just_audio/Sources/just_audio/include/just_audio/UriAudioSource.h
+++ b/just_audio/darwin/just_audio/Sources/just_audio/include/just_audio/UriAudioSource.h
@@ -13,4 +13,11 @@
 
 - (instancetype)initWithId:(NSString *)sid uri:(NSString *)uri loadControl:(LoadControl *)loadControl headers:(NSDictionary *)headers options:(NSDictionary *)options;
 
+- (instancetype)initWithId:(NSString *)sid
+                       uri:(NSString *)uri
+               loadControl:(LoadControl *)loadControl
+                   headers:(NSDictionary *)headers
+                   options:(NSDictionary *)options
+                       drm:(NSDictionary *)drm;
+
 @end

--- a/just_audio/lib/just_audio.dart
+++ b/just_audio/lib/just_audio.dart
@@ -2663,6 +2663,28 @@ abstract class AudioSource {
     return AudioSource.uri(Uri.parse('asset:///$keyName'), tag: tag);
   }
 
+  /// Convenience method to create a DRM-protected audio source for [uri],
+  /// guessing whether it should be a [DashAudioSource] or [HlsAudioSource]
+  /// from the URI's path (`.mpd`/`dash` → DASH, otherwise HLS).
+  ///
+  /// If you know in advance which stream type you have, prefer
+  /// instantiating [DashAudioSource] or [HlsAudioSource] directly with the
+  /// [drm] parameter.
+  static UriAudioSource drm({
+    required Uri uri,
+    required DrmConfiguration drm,
+    Map<String, String>? headers,
+    dynamic tag,
+  }) {
+    final path = uri.path.toLowerCase();
+    final isDash = path.endsWith('.mpd') || path.contains('dash');
+    if (isDash) {
+      return DashAudioSource(uri, headers: headers, tag: tag, drm: drm);
+    } else {
+      return HlsAudioSource(uri, headers: headers, tag: tag, drm: drm);
+    }
+  }
+
   AudioSource({String? id}) : _id = id ?? _uuid.v4();
 
   @mustCallSuper
@@ -2851,8 +2873,12 @@ class ProgressiveAudioSource extends UriAudioSource {
 /// If headers are set, just_audio will create a cleartext local HTTP proxy on
 /// your device to forward HTTP requests with headers included.
 class DashAudioSource extends UriAudioSource {
+  /// Optional DRM configuration used by the native players to acquire a
+  /// license (Widevine on Android, FairPlay on iOS/macOS) for this stream.
+  final DrmConfiguration? drm;
+
   DashAudioSource(Uri uri,
-      {Map<String, String>? headers, dynamic tag, Duration? duration})
+      {Map<String, String>? headers, dynamic tag, Duration? duration, this.drm})
       : super(uri, headers: headers, tag: tag, duration: duration);
 
   @override
@@ -2861,6 +2887,7 @@ class DashAudioSource extends UriAudioSource {
         uri: _effectiveUri.toString(),
         headers: _mergedHeaders,
         tag: tag,
+        drm: drm?._toMap(),
       );
 }
 
@@ -2878,8 +2905,12 @@ class DashAudioSource extends UriAudioSource {
 /// If headers are set, just_audio will create a cleartext local HTTP proxy on
 /// your device to forward HTTP requests with headers included.
 class HlsAudioSource extends UriAudioSource {
+  /// Optional DRM configuration used by the native players to acquire a
+  /// license (Widevine on Android, FairPlay on iOS/macOS) for this stream.
+  final DrmConfiguration? drm;
+
   HlsAudioSource(Uri uri,
-      {Map<String, String>? headers, dynamic tag, Duration? duration})
+      {Map<String, String>? headers, dynamic tag, Duration? duration, this.drm})
       : super(uri, headers: headers, tag: tag, duration: duration);
 
   @override
@@ -2888,7 +2919,40 @@ class HlsAudioSource extends UriAudioSource {
         uri: _effectiveUri.toString(),
         headers: _mergedHeaders,
         tag: tag,
+        drm: drm?._toMap(),
       );
+}
+
+/// DRM configuration for a [DashAudioSource] or [HlsAudioSource].
+///
+/// This is used by the native platform implementations to acquire a license:
+/// Widevine via [MediaItem.DrmConfiguration] on Android, and FairPlay
+/// Streaming via `AVContentKeySession` on iOS/macOS.
+///
+/// License credentials must be supplied by the app at runtime (for example via
+/// [licenseHeaders]). just_audio does not embed or manage license tokens.
+class DrmConfiguration {
+  /// The URL of the license server used to acquire a decryption key.
+  final String licenseUrl;
+
+  /// Extra HTTP headers to send with the license request.
+  final Map<String, String> licenseHeaders;
+
+  /// The URL from which to fetch the FairPlay application certificate.
+  /// Required on iOS/macOS for FairPlay Streaming; ignored on Android.
+  final String? fairplayCertUrl;
+
+  const DrmConfiguration({
+    required this.licenseUrl,
+    this.licenseHeaders = const {},
+    this.fairplayCertUrl,
+  });
+
+  Map<String, dynamic> _toMap() => {
+        'licenseUrl': licenseUrl,
+        'licenseHeaders': licenseHeaders,
+        'fairplayCertUrl': fairplayCertUrl,
+      };
 }
 
 /// An [AudioSource] for a period of silence.

--- a/just_audio/pubspec.yaml
+++ b/just_audio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: just_audio
 description: A feature-rich audio player for Flutter. Loop, clip and sequence any sound from any source (asset/file/URL/stream) in gapless playlists.
-version: 0.10.6
+version: 0.10.7
 repository: https://github.com/ryanheise/just_audio/tree/minor/just_audio
 issue_tracker: https://github.com/ryanheise/just_audio/issues
 topics:
@@ -14,9 +14,9 @@ environment:
   flutter: ">=3.27.0"
 
 dependencies:
-  just_audio_platform_interface: ^4.6.0
-  # just_audio_platform_interface:
-  #   path: ../just_audio_platform_interface
+  # just_audio_platform_interface: ^4.6.0
+  just_audio_platform_interface:
+    path: ../just_audio_platform_interface
   just_audio_web: ^0.4.15
   # just_audio_web:
   #   path: ../just_audio_web
@@ -31,6 +31,10 @@ dependencies:
   flutter:
     sdk: flutter
   synchronized: ^3.2.0
+
+dependency_overrides:
+  just_audio_platform_interface:
+    path: ../just_audio_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/just_audio_platform_interface/CHANGELOG.md
+++ b/just_audio_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.6.1
+
+* Add optional drm map to DashAudioSourceMessage and HlsAudioSourceMessage (@Francisny03).
+
 ## 4.6.0
 
 * Add androidAudioOffloadPreferences.

--- a/just_audio_platform_interface/lib/just_audio_platform_interface.dart
+++ b/just_audio_platform_interface/lib/just_audio_platform_interface.dart
@@ -1194,11 +1194,16 @@ class ProgressiveAudioSourceMessage extends UriAudioSourceMessage {
 /// Information about a DASH audio source to be communicated with the platform
 /// implementation.
 class DashAudioSourceMessage extends UriAudioSourceMessage {
+  /// Optional DRM configuration for this source, e.g.
+  /// `{'licenseUrl': ..., 'licenseHeaders': {...}, 'fairplayCertUrl': ...}`.
+  final Map<String, dynamic>? drm;
+
   DashAudioSourceMessage({
     required super.id,
     required super.uri,
     super.headers,
     super.tag,
+    this.drm,
   });
 
   @override
@@ -1207,17 +1212,23 @@ class DashAudioSourceMessage extends UriAudioSourceMessage {
         'id': id,
         'uri': uri,
         'headers': headers,
+        if (drm != null) 'drm': drm,
       };
 }
 
 /// Information about a HLS audio source to be communicated with the platform
 /// implementation.
 class HlsAudioSourceMessage extends UriAudioSourceMessage {
+  /// Optional DRM configuration for this source, e.g.
+  /// `{'licenseUrl': ..., 'licenseHeaders': {...}, 'fairplayCertUrl': ...}`.
+  final Map<String, dynamic>? drm;
+
   HlsAudioSourceMessage({
     required super.id,
     required super.uri,
     super.headers,
     super.tag,
+    this.drm,
   });
 
   @override
@@ -1226,6 +1237,7 @@ class HlsAudioSourceMessage extends UriAudioSourceMessage {
         'id': id,
         'uri': uri,
         'headers': headers,
+        if (drm != null) 'drm': drm,
       };
 }
 

--- a/just_audio_platform_interface/pubspec.yaml
+++ b/just_audio_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the just_audio plugin. Different pl
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.6.0
+version: 4.6.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Allow apps to pass license URL, headers, and FairPlay cert URL at runtime so Widevine/FairPlay streams can play without embedding secrets.