### PR TITLE
Fix stale Web audio source cache on playlist replacement

### DIFF
--- a/just_audio/example/pubspec.yaml
+++ b/just_audio/example/pubspec.yaml
@@ -20,11 +20,11 @@ dependencies:
     path: ../
 
 # Uncomment when testing platform interface changes.
-# dependency_overrides:
+dependency_overrides:
 #   just_audio_platform_interface:
 #     path: ../../just_audio_platform_interface
-#   just_audio_web:
-#     path: ../../just_audio_web
+  just_audio_web:
+    path: ../../just_audio_web
 
 dev_dependencies:
   # TODO: uncomment these dependencies when they have nullsafe versions.
@@ -32,6 +32,8 @@ dev_dependencies:
   #   sdk: flutter
   flutter_test:
     sdk: flutter
+  just_audio_platform_interface: ^4.6.0
+  just_audio_web: ^0.4.16
   # integration_test: ^1.0.1
   test: ^1.16.4
   flutter_lints: ^2.0.1

--- a/just_audio/example/test/web_audio_source_cache_test.dart
+++ b/just_audio/example/test/web_audio_source_cache_test.dart
@@ -1,0 +1,48 @@
+@TestOn('browser')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio_platform_interface/just_audio_platform_interface.dart';
+import 'package:just_audio_web/just_audio_web.dart';
+
+class RecordingHtml5AudioPlayer extends Html5AudioPlayer {
+  RecordingHtml5AudioPlayer() : super(id: 'cache-repro');
+
+  final loadedUris = <Uri>[];
+
+  @override
+  Future<Duration?> loadUri(Uri uri, Duration? initialPosition) async {
+    loadedUris.add(uri);
+    return const Duration(minutes: 1);
+  }
+}
+
+LoadRequest request(String childId, String uri) {
+  return LoadRequest(
+    audioSourceMessage: ConcatenatingAudioSourceMessage(
+      id: '',
+      children: [ProgressiveAudioSourceMessage(id: childId, uri: uri)],
+      useLazyPreparation: true,
+      shuffleOrder: const [0],
+    ),
+    initialIndex: 0,
+  );
+}
+
+void main() {
+  test(
+    'a replacement source tree with the same root ID loads its new URI',
+    () async {
+      final player = RecordingHtml5AudioPlayer();
+      addTearDown(player.release);
+
+      await player.load(request('first', 'https://example.com/first.mp3'));
+      await player.load(request('second', 'https://example.com/second.mp3'));
+
+      expect(player.loadedUris, [
+        Uri.parse('https://example.com/first.mp3'),
+        Uri.parse('https://example.com/second.mp3'),
+      ]);
+    },
+  );
+}

--- a/just_audio_web/CHANGELOG.md
+++ b/just_audio_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.17
+
+* Fix stale audio source cache when replacing the playlist (@hanxi).
+
 ## 0.4.16
 
 * Fix play interrupted by load.

--- a/just_audio_web/lib/just_audio_web.dart
+++ b/just_audio_web/lib/just_audio_web.dart
@@ -258,6 +258,7 @@ class Html5AudioPlayer extends JustAudioPlayer {
   @override
   Future<LoadResponse> load(LoadRequest request) async {
     _currentAudioSourcePlayer?.pause();
+    _audioSourcePlayers.clear();
     _audioSourcePlayer = getAudioSource(request.audioSourceMessage);
     _index = request.initialIndex ?? 0;
     final duration = await _currentAudioSourcePlayer!

--- a/just_audio_web/pubspec.yaml
+++ b/just_audio_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: just_audio_web
 description: Web platform implementation of just_audio. This implementation is endorsed and therefore doesn't require a direct dependency.
 homepage: https://github.com/ryanheise/just_audio/tree/master/just_audio_web
-version: 0.4.16
+version: 0.4.17
 
 flutter:
   plugin:


### PR DESCRIPTION
## Summary

* Rebuild the Web `AudioSourcePlayer` cache for every full `LoadRequest`.
* Keep dynamic concatenating operations working against the newly loaded source tree.
* Add a deterministic browser regression test to the official example.

## Root cause

`just_audio` reuses the root playlist ID (`''`) when replacing the playlist. `just_audio_web` retained its ID-keyed `_audioSourcePlayers` cache across full loads, so the second load could resolve the old root and child URI instead of decoding the new source tree.

Before the fix, the regression test recorded:

```text
Expected: [first.mp3, second.mp3]
Actual:   [first.mp3, first.mp3]
```

Clearing the cache at the full-load boundary preserves the existing HTML audio element while ensuring that all source players represent the authoritative replacement tree. Incremental insert/remove/move operations continue to use that new cache.

## Testing

* `flutter analyze --no-pub` in `just_audio_web`
* `flutter analyze --no-pub` in `just_audio/example`
* `flutter test --no-pub` in `just_audio/example`
* `flutter test --no-pub --platform chrome test/web_audio_source_cache_test.dart` in `just_audio/example` (Chrome for Testing 151)

Fixes #1596
